### PR TITLE
reduce alpha's precision

### DIFF
--- a/strolle-gpu/src/gbuffer.rs
+++ b/strolle-gpu/src/gbuffer.rs
@@ -88,7 +88,14 @@ impl GBufferEntry {
                     .base_color
                     .powf(1.0 / 2.2)
                     .clamp(Vec4::ZERO, Vec4::ONE);
-                let base_color = (vec4(base_color.x*255.0,base_color.y*255.0,base_color.z*255.0,base_color.w*63.0)).as_uvec4();
+                
+                let base_color = (vec4(
+                    base_color.x * 255.0,
+                    base_color.y * 255.0,
+                    base_color.z * 255.0,
+                    base_color.w * 63.0,
+                ))
+                .as_uvec4();
 
                 f32::from_bits(u32::from_bytes([
                     base_color.x,

--- a/strolle-gpu/src/gbuffer.rs
+++ b/strolle-gpu/src/gbuffer.rs
@@ -40,7 +40,7 @@ impl GBufferEntry {
                 x as f32 / 255.0,
                 y as f32 / 255.0,
                 z as f32 / 255.0,
-                w as f32 / 255.0,
+                w as f32 / 63.0,
             )
             .powf(2.2)
         };
@@ -88,8 +88,7 @@ impl GBufferEntry {
                     .base_color
                     .powf(1.0 / 2.2)
                     .clamp(Vec4::ZERO, Vec4::ONE);
-
-                let base_color = (base_color * 255.0).as_uvec4();
+                let base_color = (vec4(base_color.x*255.0,base_color.y*255.0,base_color.z*255.0,base_color.w*63.0)).as_uvec4();
 
                 f32::from_bits(u32::from_bytes([
                     base_color.x,


### PR DESCRIPTION
I've test this on Sponza and found it has white patches. This mistake mainly appears in textures of blue basecolor.
![CKXU_%H`R60${G9Y H AT O](https://github.com/Patryk27/strolle/assets/33310911/717dc20b-5a48-497c-8619-5612a9b6cc3f)

I think the process of packing basecolor's' alpha component leads to this. the operation of float on gpu is not precise and the second element {blue} suffered the greatest impact.

after:
![L6{7T(ZHVURB9WOJ5V)8SGI](https://github.com/Patryk27/strolle/assets/33310911/230aa185-282c-484d-843e-7b80f9f38edd)
