### PR TITLE
maybe mistake of lambert eq

### DIFF
--- a/strolle-shaders/src/frame_composition.rs
+++ b/strolle-shaders/src/frame_composition.rs
@@ -44,9 +44,9 @@ pub fn fs(
             if gbuffer.is_some() {
                 let gi_diff = gi_diff_colors.read(screen_pos).xyz();
                 let gi_spec = gi_spec_colors.read(screen_pos).xyz();
-
+                // L_lambert = albedo / PI * (1 - metallic) * Li * cosine
                 gbuffer.emissive
-                    + gbuffer.base_color.xyz()
+                    + gbuffer.base_color.xyz() / PI
                         * (1.0 - gbuffer.metallic)
                         * (di_diff + gi_diff)
                     + gi_spec


### PR DESCRIPTION
The di_diff you provided in frame_composition.rs (or rather, calculate in di_resolving.rs) is eq to Li * costheta. The brdf of lambert is   albedo / PI. So that the example is brighter than reference usually.
![_ PB} )A~_35Y_RTZ(IEYUL](https://github.com/Patryk27/strolle/assets/33310911/01431d76-01d8-422c-a77c-7eea787a7292)

Besides, I have a question as to why di doesn't have a specular part?
