### PR TITLE
Update from bevy 0.12 to 0.14.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 /bevy-strolle/assets/demo
 /bevy-strolle/examples/bench-*
 /bevy-strolle/examples/scene*
+/Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target
 /bevy-strolle/examples/bench-*
 /bevy-strolle/examples/scene*
 /Cargo.lock
+Cargo.lock
+*.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,3 @@ members = [
     "strolle-shaders",
 ]
 
-[patch."crates-io"]
-# TODO https://github.com/gfx-rs/naga/issues/2373
-naga = { git = "https://github.com/Patryk27/naga", branch = "v0.13.0-strolle" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,37 @@ members = [
     "strolle-shaders",
 ]
 
+[patch."crates-io"]
+bevy = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_render = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_ptr = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_utils = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_tasks = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_reflect = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_mikktspace = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_ecs = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_math = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_app = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_color = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_core = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_asset = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_a11y = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_time = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_hierarchy = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_window = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_diagnostic = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_gilrs = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_transform = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_state = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_winit = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_audio = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_core_pipeline = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_animation = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_scene = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_sprite = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_pbr = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_gizmos = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_text = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_gltf = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_ui = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }
+bevy_internal = { git = "https://github.com/glasspangolin/bevy", branch = "v0.14.2-strolle" }

--- a/bevy-strolle/Cargo.toml
+++ b/bevy-strolle/Cargo.toml
@@ -4,16 +4,20 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = "0.12.1" # TODO use default-features = false
-bevy_egui = "0.24"
+bevy = { version = "0.14.2", default-features = false, features = ["default"] }
+bevy_egui = { version = "0.29.0" }
+spirv-std = { git = "https://github.com/glasspangolin/rust-gpu.git" }
 log = "0.4.18"
 strolle = { path = "../strolle", features = ["metrics"] }
-wgpu = "0.17.2"
+wgpu = "0.20.1"
 
 [dev-dependencies]
-bevy = { version = "0.12.1", features = ["jpeg"] }
-bevy_mod_raycast = "0.16.0"
-bevy_rapier3d = "0.23.0"
-lazy_static = "1.4.0"
-smooth-bevy-cameras = "0.10.0"
-zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
+bevy = { version = "0.14.2", default-features = false, features = ["default", "jpeg"] }
+bevy_mod_raycast = { version = "0.18.0" }
+smooth-bevy-cameras = { version = "0.12.0"}
+lazy_static = "1.5.0"
+zip = { version = "2.2.0", default-features = false, features = ["deflate"] }
+
+[patch.crates-io]
+bevy = { version = "0.14.2" }
+bevy_render = {version = "0.14.2"}

--- a/bevy-strolle/examples/_common.rs
+++ b/bevy-strolle/examples/_common.rs
@@ -7,13 +7,14 @@ use std::env;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
-
+use bevy::core_pipeline::core_3d::graph::Core3d;
 use bevy::prelude::*;
 use bevy::render::camera::CameraRenderGraph;
 use bevy::window::{CursorGrabMode, PrimaryWindow};
 use bevy_strolle::prelude::*;
 use smooth_bevy_cameras::controllers::fps::FpsCameraController;
 use zip::ZipArchive;
+use bevy_strolle::graph::StrolleGraph;
 
 pub fn extract_assets() {
     extract_asset("cornell");
@@ -48,7 +49,7 @@ fn extract_asset(name: &str) {
 // -----------------------------------------------------------------------------
 
 pub fn handle_camera(
-    keys: Res<Input<KeyCode>>,
+    keys: Res<ButtonInput<KeyCode>>,
     mut window: Query<&mut Window, With<PrimaryWindow>>,
     mut camera: Query<(
         &Transform,
@@ -64,8 +65,8 @@ pub fn handle_camera(
         mut fps_camera_controller,
     ) = camera.single_mut();
 
-    if keys.just_pressed(KeyCode::Key1) {
-        camera_render_graph.set(bevy_strolle::graph::NAME);
+    if keys.just_pressed(KeyCode::Digit1) {
+        camera_render_graph.set(StrolleGraph);
 
         camera.mode = match camera.mode {
             st::CameraMode::Image { denoise } => {
@@ -75,8 +76,8 @@ pub fn handle_camera(
         };
     }
 
-    if keys.just_pressed(KeyCode::Key2) {
-        camera_render_graph.set(bevy_strolle::graph::NAME);
+    if keys.just_pressed(KeyCode::Digit2) {
+        camera_render_graph.set(StrolleGraph);
 
         camera.mode = match camera.mode {
             st::CameraMode::DiDiffuse { denoise } => {
@@ -86,8 +87,8 @@ pub fn handle_camera(
         };
     }
 
-    if keys.just_pressed(KeyCode::Key3) {
-        camera_render_graph.set(bevy_strolle::graph::NAME);
+    if keys.just_pressed(KeyCode::Digit3) {
+        camera_render_graph.set(StrolleGraph);
 
         camera.mode = match camera.mode {
             st::CameraMode::DiSpecular { denoise } => {
@@ -97,8 +98,8 @@ pub fn handle_camera(
         };
     }
 
-    if keys.just_pressed(KeyCode::Key4) {
-        camera_render_graph.set(bevy_strolle::graph::NAME);
+    if keys.just_pressed(KeyCode::Digit4) {
+        camera_render_graph.set(StrolleGraph);
 
         camera.mode = match camera.mode {
             st::CameraMode::GiDiffuse { denoise } => {
@@ -108,8 +109,8 @@ pub fn handle_camera(
         };
     }
 
-    if keys.just_pressed(KeyCode::Key5) {
-        camera_render_graph.set(bevy_strolle::graph::NAME);
+    if keys.just_pressed(KeyCode::Digit5) {
+        camera_render_graph.set(StrolleGraph);
 
         camera.mode = match camera.mode {
             st::CameraMode::GiSpecular { denoise } => {
@@ -119,20 +120,20 @@ pub fn handle_camera(
         };
     }
 
-    if keys.just_pressed(KeyCode::Key8) {
-        camera_render_graph.set(bevy_strolle::graph::NAME);
+    if keys.just_pressed(KeyCode::Digit8) {
+        camera_render_graph.set(StrolleGraph);
 
         camera.mode = st::CameraMode::BvhHeatmap;
     }
 
-    if keys.just_pressed(KeyCode::Key9) {
-        camera_render_graph.set(bevy_strolle::graph::NAME);
+    if keys.just_pressed(KeyCode::Digit9) {
+        camera_render_graph.set(StrolleGraph);
 
         camera.mode = st::CameraMode::Reference { depth: 1 };
     }
 
-    if keys.just_pressed(KeyCode::Key0) {
-        camera_render_graph.set("core_3d");
+    if keys.just_pressed(KeyCode::Digit0) {
+        camera_render_graph.set(Core3d);
     }
 
     if keys.just_pressed(KeyCode::Semicolon) {
@@ -149,7 +150,7 @@ pub fn handle_camera(
         };
     }
 
-    if keys.just_pressed(KeyCode::X) {
+    if keys.just_pressed(KeyCode::KeyX) {
         println!("{:?}", camera_xform.translation);
     }
 }
@@ -173,20 +174,20 @@ impl Default for Sun {
     }
 }
 
-pub fn handle_sun(keys: Res<Input<KeyCode>>, mut sun: ResMut<Sun>) {
-    if keys.just_pressed(KeyCode::H) {
+pub fn handle_sun(keys: Res<ButtonInput<KeyCode>>, mut sun: ResMut<Sun>) {
+    if keys.just_pressed(KeyCode::KeyH) {
         sun.azimuth -= 0.05;
     }
 
-    if keys.just_pressed(KeyCode::J) {
+    if keys.just_pressed(KeyCode::KeyJ) {
         sun.altitude -= 0.05;
     }
 
-    if keys.just_pressed(KeyCode::K) {
+    if keys.just_pressed(KeyCode::KeyK) {
         sun.altitude += 0.05;
     }
 
-    if keys.just_pressed(KeyCode::L) {
+    if keys.just_pressed(KeyCode::KeyL) {
         sun.azimuth += 0.05;
     }
 }

--- a/bevy-strolle/examples/cornell.rs
+++ b/bevy-strolle/examples/cornell.rs
@@ -6,6 +6,7 @@ use bevy::math::vec3;
 use bevy::prelude::*;
 use bevy::render::camera::CameraRenderGraph;
 use bevy::window::WindowResolution;
+use bevy_strolle::graph::StrolleGraph;
 use bevy_strolle::prelude::*;
 use smooth_bevy_cameras::controllers::orbit::{
     OrbitCameraBundle, OrbitCameraController, OrbitCameraPlugin,
@@ -56,14 +57,14 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
     commands
         .spawn(Camera3dBundle {
             camera_render_graph: CameraRenderGraph::new(
-                bevy_strolle::graph::NAME,
+                StrolleGraph,
             ),
             camera: Camera {
                 hdr: true,
                 ..default()
             },
             ..default()
-        })
+        }).insert(StrolleCamera::default())
         .insert(OrbitCameraBundle::new(
             {
                 OrbitCameraController {

--- a/bevy-strolle/examples/demo.rs
+++ b/bevy-strolle/examples/demo.rs
@@ -2,12 +2,14 @@
 mod common;
 
 use std::f32::consts::PI;
-
-use bevy::core_pipeline::clear_color::ClearColorConfig;
+use bevy::asset::AssetContainer;
 use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin};
 use bevy::math::{uvec2, vec3};
 use bevy::prelude::*;
 use bevy::render::camera::{CameraRenderGraph, RenderTarget};
+use bevy::render::renderer::RenderDevice;
+use bevy::render::RenderPlugin;
+use bevy::render::settings::{RenderCreation, WgpuSettings};
 use bevy::render::texture::ImageSampler;
 use bevy::window::{CursorGrabMode, PrimaryWindow, WindowResolution};
 use bevy_strolle::prelude::*;
@@ -15,10 +17,8 @@ use smooth_bevy_cameras::controllers::fps::{
     FpsCameraBundle, FpsCameraController, FpsCameraPlugin,
 };
 use smooth_bevy_cameras::LookTransformPlugin;
-use wgpu::{
-    Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
-};
-
+use wgpu::{Extent3d, Limits, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages};
+use bevy_strolle::graph::StrolleGraph;
 use self::common::Sun;
 
 const VIEWPORT_SIZE: UVec2 = uvec2(640, 480);
@@ -48,6 +48,7 @@ fn main() {
         .add_systems(Startup, setup_window)
         .add_systems(Startup, setup_camera)
         .add_systems(Startup, setup_scene)
+        .add_systems(Startup, check_gpu_limits)
         .add_systems(Update, adjust_materials)
         .add_systems(Update, handle_materials)
         .add_systems(Update, common::handle_camera)
@@ -58,6 +59,21 @@ fn main() {
         .add_systems(Update, animate_toruses)
         .insert_resource(Sun::default())
         .run();
+}
+
+fn check_gpu_limits(render_device: Res<RenderDevice>) {
+    let limits = render_device.limits();
+    info!("GPU Limits:");
+    info!("  max_color_attachment_bytes_per_sample: {}",
+          limits.max_color_attachment_bytes_per_sample);
+    info!("  max_texture_dimension_2d: {}",
+          limits.max_texture_dimension_2d);
+    info!("  max_storage_buffer_binding_size: {}",
+          limits.max_storage_buffer_binding_size);
+    info!("  max_bind_groups: {}",
+          limits.max_bind_groups);
+    info!("  max_bindings_per_bind_group: {}",
+          limits.max_bindings_per_bind_group);
 }
 
 fn setup_window(mut window: Query<&mut Window, With<PrimaryWindow>>) {
@@ -118,16 +134,13 @@ fn setup_camera(
             order: 1,
             ..default()
         },
-        camera_2d: Camera2d {
-            clear_color: ClearColorConfig::None,
-        },
+        camera_2d: Camera2d {},
         ..default()
     });
 
-    commands
-        .spawn(Camera3dBundle {
+    commands.spawn(Camera3dBundle {
             camera_render_graph: CameraRenderGraph::new(
-                bevy_strolle::graph::NAME,
+                StrolleGraph,
             ),
             camera: Camera {
                 order: 0,
@@ -136,8 +149,7 @@ fn setup_camera(
                 ..default()
             },
             ..default()
-        })
-        .insert(StrolleCamera::default())
+        }).insert(StrolleCamera::default())
         .insert(FpsCameraBundle::new(
             {
                 FpsCameraController {
@@ -181,7 +193,7 @@ fn setup_scene(
                 color: Color::WHITE,
                 range: 35.0,
                 radius: 0.15,
-                intensity: 5000.0,
+                intensity: 1000.0,
                 shadows_enabled: true,
                 ..default()
             },
@@ -203,10 +215,10 @@ fn setup_scene(
 
         commands
             .spawn(MaterialMeshBundle {
-                mesh: meshes.add(Mesh::from(shape::Torus::default())),
+                mesh: meshes.add(Mesh::from(Torus::default())),
                 material: materials.add(StandardMaterial {
                     base_color: color,
-                    emissive: color * 10.0,
+                    emissive: color.to_linear(),
                     ..default()
                 }),
                 transform: Transform::from_translation(torus)
@@ -214,7 +226,7 @@ fn setup_scene(
                     .with_scale(Vec3::splat(0.5)),
                 ..default()
             })
-            .insert(Torus);
+            .insert(StrTorus);
     }
 
     // ---
@@ -261,16 +273,16 @@ fn adjust_materials(
 }
 
 fn handle_materials(
-    keys: Res<Input<KeyCode>>,
+    keys: Res<ButtonInput<KeyCode>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    if keys.just_pressed(KeyCode::T) {
+    if keys.just_pressed(KeyCode::KeyT) {
         for (_, material) in materials.iter_mut() {
             material.base_color_texture = None;
         }
     }
 
-    if keys.just_pressed(KeyCode::M) {
+    if keys.just_pressed(KeyCode::KeyM) {
         for (_, material) in materials.iter_mut() {
             if material.metallic == 0.0 {
                 material.metallic = 1.0;
@@ -291,13 +303,13 @@ struct Flashlight {
 }
 
 fn handle_flashlight(
-    keys: Res<Input<KeyCode>>,
+    keys: Res<ButtonInput<KeyCode>>,
     mut flashlight: Query<(&mut Flashlight, &mut SpotLight)>,
     mut lights: Query<&mut PointLight>,
 ) {
     let (mut flashlight, mut flashlight_spot) = flashlight.single_mut();
 
-    if keys.just_pressed(KeyCode::F) {
+    if keys.just_pressed(KeyCode::KeyF) {
         flashlight.enabled = !flashlight.enabled;
 
         if flashlight.enabled {
@@ -330,11 +342,11 @@ fn animate_flashlight(
 // -----------------------------------------------------------------------------
 
 #[derive(Component)]
-struct Torus;
+struct StrTorus;
 
 fn animate_toruses(
     time: Res<Time>,
-    mut toruses: Query<&mut Transform, (With<Torus>, Without<Flashlight>)>,
+    mut toruses: Query<&mut Transform, (With<StrTorus>, Without<Flashlight>)>,
 ) {
     for mut xform in toruses.iter_mut() {
         xform.rotation = Quat::from_rotation_z(time.elapsed_seconds())

--- a/bevy-strolle/src/debug.rs
+++ b/bevy-strolle/src/debug.rs
@@ -2,6 +2,7 @@ use bevy::core_pipeline::fxaa;
 use bevy::core_pipeline::tonemapping::Tonemapping;
 use bevy::prelude::*;
 use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use crate::utils::color_to_vec4;
 
 pub struct StrolleDebugPlugin;
 
@@ -89,7 +90,7 @@ fn draw_materials(
                     return;
                 };
 
-                let rgba = material.base_color.as_rgba_f32();
+                let rgba = color_to_vec4(material.base_color);
                 let mut rgb = [rgba[0], rgba[1], rgba[2]];
 
                 ui.color_edit_button_rgb(&mut rgb);

--- a/bevy-strolle/src/graph.rs
+++ b/bevy-strolle/src/graph.rs
@@ -1,43 +1,45 @@
-pub const NAME: &str = "strolle";
-
-pub mod node {
-    pub const RENDERING: &str = "strolle_rendering";
-    pub const TONEMAPPING: &str = "strolle_tonemapping";
-    pub const FXAA: &str = "strolle_fxaa";
-    pub const UPSCALING: &str = "strolle_upscaling";
-}
-
 use bevy::core_pipeline::fxaa::FxaaNode;
 use bevy::core_pipeline::tonemapping::TonemappingNode;
 use bevy::core_pipeline::upscaling::UpscalingNode;
 use bevy::prelude::*;
-use bevy::render::render_graph::{RenderGraphApp, ViewNodeRunner};
-
+use bevy::render::render_graph::{RenderGraphApp, RenderSubGraph, ViewNodeRunner};
+use crate::prelude::RenderLabel;
 use crate::RenderingNode;
 
-pub(crate) fn setup(render_app: &mut App) {
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, RenderSubGraph)]
+pub struct StrolleGraph;
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, RenderLabel)]
+pub enum StrolleNode {
+    RENDERING,
+    TONEMAPPING,
+    FXAA,
+    UPSCALING
+}
+
+pub fn setup(render_app: &mut SubApp) {
     render_app
-        .add_render_sub_graph(NAME)
+        .add_render_sub_graph(StrolleGraph)
         .add_render_graph_node::<ViewNodeRunner<RenderingNode>>(
-            NAME,
-            node::RENDERING,
+            StrolleGraph,
+            StrolleNode::RENDERING,
         )
         .add_render_graph_node::<ViewNodeRunner<TonemappingNode>>(
-            NAME,
-            node::TONEMAPPING,
+            StrolleGraph,
+            StrolleNode::TONEMAPPING,
         )
         .add_render_graph_node::<ViewNodeRunner<UpscalingNode>>(
-            NAME,
-            node::UPSCALING,
+            StrolleGraph,
+            StrolleNode::UPSCALING,
         )
-        .add_render_graph_node::<ViewNodeRunner<FxaaNode>>(NAME, node::FXAA)
+        .add_render_graph_node::<ViewNodeRunner<FxaaNode>>(StrolleGraph, StrolleNode::FXAA)
         .add_render_graph_edges(
-            NAME,
-            &[
-                node::RENDERING,
-                node::FXAA,
-                node::TONEMAPPING,
-                node::UPSCALING,
-            ],
+            StrolleGraph, (
+                StrolleNode::RENDERING,
+                StrolleNode::FXAA,
+                StrolleNode::TONEMAPPING,
+                StrolleNode::UPSCALING,
+            ),
         );
 }

--- a/bevy-strolle/src/lib.rs
+++ b/bevy-strolle/src/lib.rs
@@ -15,6 +15,7 @@ pub mod prelude {
 use std::ops;
 
 use bevy::prelude::*;
+use bevy::render::render_graph::RenderLabel;
 use bevy::render::render_resource::Texture;
 use bevy::render::renderer::RenderDevice;
 use bevy::render::RenderApp;
@@ -29,12 +30,14 @@ pub use self::sun::*;
 
 pub struct StrollePlugin;
 
+
+
 impl Plugin for StrollePlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<StrolleEvent>();
         app.insert_resource(StrolleSun::default());
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+        if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.insert_resource(SyncedState::default());
 
             stages::setup(render_app);
@@ -43,11 +46,11 @@ impl Plugin for StrollePlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
 
-        let render_device = render_app.world.resource::<RenderDevice>();
+        let render_device = render_app.world().resource::<RenderDevice>();
         let engine = st::Engine::new(render_device.wgpu_device());
 
         render_app.insert_resource(EngineResource(engine));

--- a/bevy-strolle/src/rendering_node.rs
+++ b/bevy-strolle/src/rendering_node.rs
@@ -23,8 +23,11 @@ impl ViewNode for RenderingNode {
         let state = world.resource::<SyncedState>();
 
         let Some(camera) = state.cameras.get(&entity) else {
+            println!("No camera");
             return Ok(());
         };
+
+        //println!("Starting render for camera {:?}", entity);
 
         engine.render_camera(
             camera.handle,

--- a/bevy-strolle/src/stages.rs
+++ b/bevy-strolle/src/stages.rs
@@ -4,7 +4,7 @@ mod prepare;
 use bevy::prelude::*;
 use bevy::render::{Render, RenderSet};
 
-pub(crate) fn setup(render_app: &mut App) {
+pub fn setup(render_app: &mut SubApp) {
     render_app.add_systems(
         ExtractSchedule,
         extract::meshes.in_set(RenderSet::ExtractCommands),
@@ -58,6 +58,5 @@ pub(crate) fn setup(render_app: &mut App) {
     render_app.add_systems(Render, prepare::sun.in_set(RenderSet::Prepare));
     render_app.add_systems(Render, prepare::cameras.in_set(RenderSet::Prepare));
 
-    render_app
-        .add_systems(Render, prepare::flush.in_set(RenderSet::PrepareFlush));
+    render_app.add_systems(Render, prepare::flush.in_set(RenderSet::PrepareResourcesFlush));
 }

--- a/bevy-strolle/src/stages/extract.rs
+++ b/bevy-strolle/src/stages/extract.rs
@@ -33,9 +33,8 @@ pub(crate) fn meshes(
             AssetEvent::Removed { id } => {
                 removed.push(*id);
             }
-            AssetEvent::LoadedWithDependencies { .. } => {
-                //
-            }
+            AssetEvent::Unused { .. } => {}
+            AssetEvent::LoadedWithDependencies { .. } => {}
         }
     }
 
@@ -76,6 +75,7 @@ pub(crate) fn materials(
             AssetEvent::LoadedWithDependencies { .. } => {
                 //
             }
+            AssetEvent::Unused { .. } => {}
         }
     }
 
@@ -130,6 +130,7 @@ pub(crate) fn images(
             AssetEvent::LoadedWithDependencies { .. } => {
                 //
             }
+            AssetEvent::Unused { .. } => {}
         }
     }
 
@@ -235,7 +236,7 @@ pub(crate) fn instances(
                 //      should probably propagate the layers up to the BVH
                 //      leaves and adjust the raytracer to read those
                 if let Some(layers) = layers {
-                    if *layers != RenderLayers::all() {
+                    if *layers != RenderLayers::layer(0) {
                         // TODO inefficient; we should push only if the object
                         //      was visible before
                         removed.push(handle);
@@ -337,36 +338,21 @@ pub(crate) fn lights(
 #[allow(clippy::type_complexity)]
 pub(crate) fn cameras(
     mut commands: Commands,
-    cameras: Extract<
-        Query<(
-            Entity,
-            &Camera,
-            &CameraRenderGraph,
-            &Projection,
-            &GlobalTransform,
-            Option<&StrolleCamera>,
-        )>,
-    >,
+    cameras: Extract<Query<(
+        Entity,
+        &Camera,
+        &GlobalTransform,
+        &StrolleCamera,
+    )>>,
 ) {
-    for (
-        entity,
-        camera,
-        camera_render_graph,
-        projection,
-        transform,
-        strolle_camera,
-    ) in cameras.iter()
-    {
-        if !camera.is_active || **camera_render_graph != crate::graph::NAME {
-            continue;
-        }
+
+    for (entity, camera, transform, strolle_camera) in cameras.iter() {
 
         assert!(camera.hdr, "Strolle requires an HDR camera");
 
         commands.get_or_spawn(entity).insert(ExtractedCamera {
             transform: transform.compute_matrix(),
-            projection: projection.get_projection_matrix(),
-            mode: strolle_camera.map(|camera| camera.mode),
+            mode: Some(strolle_camera.mode),
         });
     }
 }

--- a/bevy-strolle/src/state.rs
+++ b/bevy-strolle/src/state.rs
@@ -106,7 +106,6 @@ pub(crate) struct ExtractedLight {
 #[derive(Debug, Component)]
 pub(crate) struct ExtractedCamera {
     pub transform: Mat4,
-    pub projection: Mat4,
     pub mode: Option<st::CameraMode>,
 }
 

--- a/bevy-strolle/src/utils.rs
+++ b/bevy-strolle/src/utils.rs
@@ -1,14 +1,16 @@
-use bevy::math::{vec3, vec4};
+
 use bevy::prelude::*;
 
 pub fn color_to_vec3(color: Color) -> Vec3 {
-    let [r, g, b, _] = color.as_linear_rgba_f32();
+    let [r, g, b, _] = color.to_linear().to_f32_array();
 
-    vec3(r, g, b)
+    Vec3::new(r, g, b)
 }
 
 pub fn color_to_vec4(color: Color) -> Vec4 {
-    let [r, g, b, a] = color.as_linear_rgba_f32();
+    let [r, g, b, a] = color.to_linear().to_f32_array();
 
-    vec4(r, g, b, a)
+    Vec4::new(r, g, b, a)
 }
+
+

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-09-30"
-components = ["cargo", "rust-src", "rustc-dev", "llvm-tools-preview"]
+channel = "nightly-2024-04-24"
+components = ["rust-src", "rustc-dev", "llvm-tools"]

--- a/strolle-gpu/Cargo.toml
+++ b/strolle-gpu/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bytemuck = { version = "1.13.1", features = ["derive", "min_const_generics"] }
-glam = { version = "0.24", default-features = false, features = ["bytemuck"] }
-spirv-std = { git = "https://github.com/EmbarkStudios/rust-gpu" }
+bytemuck = { version = "1.19.0", features = ["derive", "min_const_generics"] }
+glam = { version = "0.29.1", default-features = false, features = ["bytemuck"] }
+spirv-std = { git = "https://github.com/glasspangolin/rust-gpu.git" }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/strolle-gpu/src/brdf.rs
+++ b/strolle-gpu/src/brdf.rs
@@ -4,7 +4,7 @@ use glam::{Vec3, Vec4Swizzles};
 #[cfg(target_arch = "spirv")]
 use spirv_std::num_traits::Float;
 
-use crate::{F32Ext, GBufferEntry, WhiteNoise};
+use crate::{safe_any_orthonormal_pair, safe_normalize, F32Ext, GBufferEntry, WhiteNoise};
 
 #[derive(Clone, Copy)]
 pub struct DiffuseBrdf {
@@ -52,7 +52,7 @@ impl SpecularBrdf {
 
         let a = gbuffer.clamped_roughness();
         let n = gbuffer.normal;
-        let h = (l + v).normalize();
+        let h = safe_normalize(l + v);
         let n_dot_l = n.dot(l).saturate();
         let n_dot_h = n.dot(h).saturate();
         let l_dot_h = l.dot(h).saturate();
@@ -88,10 +88,10 @@ impl SpecularBrdf {
         let a = gbuffer.clamped_roughness();
         let n = gbuffer.normal;
         let a2 = a.sqr();
-        let (b, t) = n.any_orthonormal_pair();
+        let (b, t) = safe_any_orthonormal_pair(n);
 
-        let cos_theta = 0.0f32.max((1.0 - r0) / ((a2 - 1.0) * r0 + 1.0)).sqrt();
-        let sin_theta = 0.0f32.max(1.0 - cos_theta * cos_theta).sqrt();
+        let cos_theta = 0.0f32.max((1.0 - r0) / ((a2 - 1.0) * r0 + 1.0)).max(crate::STROLLE_EPSILON).sqrt();
+        let sin_theta = 0.0f32.max(1.0 - cos_theta * cos_theta).max(crate::STROLLE_EPSILON).sqrt();
 
         let phi = r1 * PI * 2.0;
 
@@ -102,7 +102,7 @@ impl SpecularBrdf {
         let n_dot_h = n.dot(h).saturate();
         let h_dot_v = h.dot(v).saturate();
 
-        let dir = (2.0 * h_dot_v * h - v).normalize();
+        let dir = safe_normalize(2.0 * h_dot_v * h - v);
         let pdf = ggx_distribution(n_dot_h, a) * n_dot_h / (4.0 * h_dot_v);
 
         BrdfSample {

--- a/strolle-gpu/src/camera.rs
+++ b/strolle-gpu/src/camera.rs
@@ -81,15 +81,14 @@ impl Camera {
         let screen_size = self.screen.xy();
         let screen_pos = screen_pos.as_vec2() + vec2(0.5, 0.5);
 
-        let ndc = screen_pos * 2.0 / screen_size - Vec2::ONE;
+        let ndc = screen_pos * 2.0 / Vec2::new((screen_size.x).max(crate::STROLLE_EPSILON), (screen_size.y).max(crate::STROLLE_EPSILON)) - Vec2::ONE;
         let ndc = vec2(ndc.x, -ndc.y);
 
-        let far_plane =
-            self.ndc_to_world.project_point3(ndc.extend(f32::EPSILON));
+        let far_plane = self.ndc_to_world.project_point3(ndc.extend(crate::STROLLE_EPSILON));
 
         let near_plane = self.ndc_to_world.project_point3(ndc.extend(1.0));
 
-        Ray::new(near_plane, (far_plane - near_plane).normalize())
+        Ray::new(near_plane, crate::safe_normalize(far_plane - near_plane))
     }
 
     /// Returns camera's approximate origin, without taking into account the

--- a/strolle-gpu/src/gbuffer.rs
+++ b/strolle-gpu/src/gbuffer.rs
@@ -20,30 +20,27 @@ impl GBufferEntry {
         let depth = d0.x;
         let normal = Normal::decode(d0.yz());
 
-        let (metallic, roughness, reflectance) = {
-            let [metallic, roughness, reflectance, ..] =
-                d0.w.to_bits().to_bytes();
+        let packed = d0.w.to_bits();
+        let metallic_u = (packed >> 24) & 0xFF;
+        let roughness_u = (packed >> 16) & 0xFF;
+        let reflectance_u = (packed >> 8) & 0xFF;
+        let emissive_r_u = packed & 0xFF;
 
-            let metallic = metallic as f32 / 255.0;
-            let roughness = (roughness as f32 / 255.0).sqr();
-            let reflectance = reflectance as f32 / 255.0;
+        let metallic = metallic_u as f32 / 255.0;
+        let roughness = roughness_u as f32 / 255.0;
+        let reflectance = reflectance_u as f32 / 255.0;
+        let emissive_r = emissive_r_u as f32 / 255.0;
 
-            (metallic, roughness, reflectance)
-        };
+        let w_scaled = d1.w as u32;
+        let emissive_g_u = (w_scaled >> 8) & 0xFF;
+        let emissive_b_u = w_scaled & 0xFF;
 
-        let emissive = d1.xyz();
+        let emissive_g = emissive_g_u as f32 / 255.0;
+        let emissive_b = emissive_b_u as f32 / 255.0;
 
-        let base_color = {
-            let [x, y, z, w] = d1.w.to_bits().to_bytes();
+        let emissive = Vec3::new(emissive_r, emissive_g, emissive_b);
 
-            vec4(
-                x as f32 / 255.0,
-                y as f32 / 255.0,
-                z as f32 / 255.0,
-                w as f32 / 63.0,
-            )
-            .powf(2.2)
-        };
+        let base_color = vec4(d1.x, d1.y, d1.z, 1.0); // Assuming alpha is 1.0
 
         Self {
             base_color,
@@ -57,55 +54,43 @@ impl GBufferEntry {
     }
 
     pub fn pack(self) -> [Vec4; 2] {
+        // d0: Rgba32Float
         let d0 = {
-            let x = self.depth;
-            let Vec2 { x: y, y: z } = Normal::encode(self.normal);
+            let x = self.depth; // f32
+            let Vec2 { x: y, y: z } = Normal::encode(self.normal); // Encoded normal components
 
-            let w = {
-                let metallic = self.metallic.clamp(0.0, 1.0) * 255.0;
-                let roughness = self.roughness.sqrt().clamp(0.0, 1.0) * 255.0;
-                let reflectance = self.reflectance.clamp(0.0, 1.0) * 255.0;
+            // Pack metallic, roughness, reflectance, and emissive_r into a u32
+            let metallic_u = (self.metallic.clamp(0.0, 1.0) * 255.0).round() as u32;
+            let roughness_u = (self.roughness.clamp(0.0, 1.0) * 255.0).round() as u32;
+            let reflectance_u = (self.reflectance.clamp(0.0, 1.0) * 255.0).round() as u32;
+            let emissive_r_u = (self.emissive.x.clamp(0.0, 1.0) * 255.0).round() as u32;
 
-                f32::from_bits(u32::from_bytes([
-                    metallic as u32,
-                    roughness as u32,
-                    reflectance as u32,
-                    1,
-                ]))
-            };
+            let packed = (metallic_u << 24)
+                | (roughness_u << 16)
+                | (reflectance_u << 8)
+                | emissive_r_u;
+
+            let w = f32::from_bits(packed);
 
             vec4(x, y, z, w)
         };
 
+        // d1: Rgba16Float
         let d1 = {
-            // TODO doesn't need to use as much space
-            let x = self.emissive.x;
-            let y = self.emissive.y;
-            let z = self.emissive.z;
+            let base_color = self.base_color.clamp(Vec4::ZERO, Vec4::ONE);
 
-            let w = {
-                let base_color = self
-                    .base_color
-                    .powf(1.0 / 2.2)
-                    .clamp(Vec4::ZERO, Vec4::ONE);
+            let emissive_g_u = (self.emissive.y.clamp(0.0, 1.0) * 255.0).round() as u32;
+            let emissive_b_u = (self.emissive.z.clamp(0.0, 1.0) * 255.0).round() as u32;
 
-                let base_color = (vec4(
-                    base_color.x * 255.0,
-                    base_color.y * 255.0,
-                    base_color.z * 255.0,
-                    base_color.w * 63.0,
-                ))
-                .as_uvec4();
+            let emissive_packed = (emissive_g_u << 8) | emissive_b_u;
+            let w = emissive_packed as f32;
 
-                f32::from_bits(u32::from_bytes([
-                    base_color.x,
-                    base_color.y,
-                    base_color.z,
-                    base_color.w,
-                ]))
-            };
-
-            vec4(x, y, z, w)
+            vec4(
+                base_color.x,
+                base_color.y,
+                base_color.z,
+                w, // Store packed emissive_g and emissive_b
+            )
         };
 
         [d0, d1]

--- a/strolle-gpu/src/hit.rs
+++ b/strolle-gpu/src/hit.rs
@@ -84,7 +84,7 @@ pub struct TriangleHit {
 impl TriangleHit {
     pub fn none() -> Self {
         Self {
-            distance: f32::MAX,
+            distance: 1000_000f32,
             point: Default::default(),
             normal: Default::default(),
             uv: Default::default(),
@@ -120,7 +120,7 @@ impl TriangleHit {
     }
 
     pub fn is_some(self) -> bool {
-        self.distance < f32::MAX
+        self.distance < 1000_000f32
     }
 
     pub fn is_none(self) -> bool {

--- a/strolle-gpu/src/light.rs
+++ b/strolle-gpu/src/light.rs
@@ -1,17 +1,17 @@
 use core::f32::consts::PI;
 use core::ops::Mul;
-
 use bytemuck::{Pod, Zeroable};
 use glam::{vec2, vec4, Vec2, Vec3, Vec4, Vec4Swizzles};
 #[cfg(target_arch = "spirv")]
 use spirv_std::num_traits::Float;
 
 use crate::{
-    DiffuseBrdf, F32Ext, Hit, Normal, Ray, SpecularBrdf, Vec3Ext, WhiteNoise,
+    safe_any_orthonormal_pair, safe_normalize,
+    DiffuseBrdf, F32Ext, Hit, Normal, Ray, SpecularBrdf, Vec3Ext, WhiteNoise
 };
 
 #[repr(C)]
-#[derive(Clone, Copy, Default, Pod, Zeroable)]
+#[derive(Clone, Copy, Pod, Zeroable)]
 #[cfg_attr(not(target_arch = "spirv"), derive(Debug))]
 pub struct Light {
     /// x - position x
@@ -41,6 +41,21 @@ pub struct Light {
     pub prev_d2: Vec4,
 }
 
+impl Default for Light {
+    fn default() -> Self {
+        Self {
+            d0: Vec4::new(0.0, 0.0, 0.0, 1.0),  // Non-zero radius
+            d1: Vec4::new(0.0, 0.0, 0.0, 1.0),  // Non-zero range
+            d2: Vec4::ZERO,
+            d3: Vec4::ZERO,
+            prev_d0: Vec4::ZERO,
+            prev_d1: Vec4::ZERO,
+            prev_d2: Vec4::ZERO,
+        }
+    }
+}
+
+
 impl Light {
     pub const TYPE_NONE: u32 = 0;
     pub const TYPE_POINT: u32 = 1;
@@ -50,7 +65,7 @@ impl Light {
         Self {
             // TODO incorrect
             d0: position.extend(25.0),
-            d1: color.extend(f32::INFINITY),
+            d1: color.extend(1000_000f32),
             d2: vec4(
                 f32::from_bits(Self::TYPE_POINT),
                 Default::default(),
@@ -125,7 +140,7 @@ impl Light {
     }
 
     pub fn clear_slot(&mut self) {
-        self.d3.x = f32::from_bits(0);
+        self.d3.x = f32::from_bits(1);
     }
 
     pub fn commit(&mut self) {
@@ -152,7 +167,7 @@ impl Light {
             (1.0 - (angle / self.spot_angle()).powf(3.0)).saturate()
         };
 
-        let f_dist = if self.range() == f32::INFINITY {
+        let f_dist = if self.range() == 1000_000f32 {
             1.0
         } else {
             let l2 = l.length_squared();
@@ -216,23 +231,27 @@ impl Light {
 
     pub fn ray_bnoise(self, sample: Vec2, hit_point: Vec3) -> Ray {
         let to_light = self.center() - hit_point;
-        let light_dir = to_light.normalize();
         let light_distance = to_light.length();
-        let light_radius = self.radius() / light_distance;
-        let (light_tangent, light_bitangent) = light_dir.any_orthonormal_pair();
+
+        // Avoid potential division by zero or very small numbers
+        let safe_distance = light_distance.max(1.0);
+        let light_dir = to_light / safe_distance;
+
+        // Use clamped values for radius calculations
+        let safe_radius = self.radius().max(crate::STROLLE_EPSILON);
+        let light_radius = (safe_radius / safe_distance).min(10.0);
+
+        let (light_tangent, light_bitangent) = safe_any_orthonormal_pair(light_dir);
 
         let disk_point = {
             let angle = 2.0 * PI * sample.x;
-            let radius = sample.y.sqrt();
-
+            let radius = sample.y.max(crate::STROLLE_EPSILON).sqrt();
             vec2(angle.sin(), angle.cos()) * radius * light_radius
         };
 
-        let ray_dir = light_dir
+        let ray_dir = safe_normalize(light_dir
             + disk_point.x * light_tangent
-            + disk_point.y * light_bitangent;
-
-        let ray_dir = ray_dir.normalize();
+            + disk_point.y * light_bitangent);
 
         Ray::new(hit_point + ray_dir * light_distance, -ray_dir)
             .with_len(light_distance)

--- a/strolle-gpu/src/noise/white.rs
+++ b/strolle-gpu/src/noise/white.rs
@@ -4,7 +4,7 @@ use glam::{vec2, vec3, UVec2, Vec2, Vec3};
 #[cfg(target_arch = "spirv")]
 use spirv_std::num_traits::Float;
 
-use crate::F32Ext;
+use crate::{safe_any_orthonormal_pair, F32Ext};
 
 #[derive(Clone, Copy)]
 pub struct WhiteNoise {
@@ -74,9 +74,9 @@ impl WhiteNoise {
     /// Generates a uniform sample on a hemisphere around given normal.
     pub fn sample_hemisphere(&mut self, normal: Vec3) -> Vec3 {
         let cos_theta = self.sample();
-        let sin_theta = (1.0f32 - cos_theta.sqr()).sqrt();
+        let sin_theta = (1.0f32 - cos_theta.sqr()).max(0.0).sqrt();
         let phi = 2.0 * PI * self.sample();
-        let (t, b) = normal.any_orthonormal_pair();
+        let (t, b) = safe_any_orthonormal_pair(normal);
 
         (t * phi.cos() + b * phi.sin()) * sin_theta + normal * cos_theta
     }

--- a/strolle-gpu/src/ray.rs
+++ b/strolle-gpu/src/ray.rs
@@ -21,12 +21,22 @@ pub struct Ray {
 
 impl Ray {
     pub fn new(origin: Vec3, dir: Vec3) -> Self {
-        Self {
-            origin,
-            dir,
-            inv_dir: 1.0 / dir,
-            len: f32::MAX,
+        if dir.length() > 0.01 {
+            Self {
+                origin,
+                dir,
+                inv_dir: 1.0 / dir,
+                len: 1000_000f32,
+            }
+        } else {
+            Self {
+                origin,
+                dir,
+                inv_dir: Vec3::ZERO,
+                len: 1000_000f32,
+            }
         }
+
     }
 
     pub fn with_len(mut self, len: f32) -> Self {
@@ -280,7 +290,7 @@ impl Ray {
         }
 
         let mut tmin = 0.0;
-        let mut tmax = f32::MAX;
+        let mut tmax = 1000_000f32;
 
         let t1 = (aabb_min - self.origin) * self.inv_dir;
         let t2 = (aabb_max - self.origin) * self.inv_dir;
@@ -297,7 +307,7 @@ impl Ray {
         if tmin <= tmax {
             tmin
         } else {
-            f32::MAX
+            1000_000f32
         }
     }
 

--- a/strolle-gpu/src/reservoir/di.rs
+++ b/strolle-gpu/src/reservoir/di.rs
@@ -13,52 +13,55 @@ pub struct DiReservoir {
     pub reservoir: Reservoir<DiSample>,
 }
 
-impl DiReservoir {
-    pub fn read(buffer: &[Vec4], id: usize) -> Self {
-        let d0 = unsafe { *buffer.index_unchecked(2 * id) };
-        let d1 = unsafe { *buffer.index_unchecked(2 * id + 1) };
-        let [is_occluded, confidence, ..] = d0.w.to_bits().to_bytes();
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct DiReservoirData {
+    pub m: f32,
+    pub w: f32,
+    pub pdf: f32,
+    pub confidence: f32,
+    pub is_occluded: u32,
+    pub light_id: u32,
+    // Add padding to align `light_point` to 16 bytes
+    _padding0: [u32; 2],
+    pub light_point: Vec3
+}
 
+impl DiReservoir {
+    pub fn read(buffer: &[DiReservoirData], id: usize) -> Self {
+        let data = unsafe { *buffer.index_unchecked(id) };
         Self {
             reservoir: Reservoir {
                 sample: DiSample {
-                    pdf: d0.z,
-                    confidence: confidence as f32,
-                    light_id: LightId::new(d1.w.to_bits()),
-                    light_point: d1.xyz(),
-                    is_occluded: is_occluded > 0,
+                    pdf: data.pdf,
+                    confidence: data.confidence,
+                    light_id: LightId::new(data.light_id),
+                    light_point: data.light_point,
+                    is_occluded: data.is_occluded != 0,
                 },
-                m: d0.x,
-                w: d0.y,
+                m: data.m,
+                w: data.w,
             },
         }
     }
 
-    pub fn write(self, buffer: &mut [Vec4], id: usize) {
-        let d0 = vec4(
-            self.reservoir.m,
-            self.reservoir.w,
-            self.sample.pdf,
-            f32::from_bits(u32::from_bytes([
-                self.sample.is_occluded as u32,
-                self.sample.confidence as u32,
-                0,
-                0,
-            ])),
-        );
-
-        let d1 = self
-            .sample
-            .light_point
-            .extend(f32::from_bits(self.sample.light_id.get()));
-
+    pub fn write(self, buffer: &mut [DiReservoirData], id: usize) {
+        let data = DiReservoirData {
+            m: self.reservoir.m,
+            w: self.reservoir.w,
+            pdf: self.sample.pdf,
+            confidence: self.sample.confidence,
+            is_occluded: self.sample.is_occluded as u32,
+            light_id: self.sample.light_id.get(),
+            _padding0: [0u32; 2],
+            light_point: self.sample.light_point
+        };
         unsafe {
-            *buffer.index_unchecked_mut(2 * id) = d0;
-            *buffer.index_unchecked_mut(2 * id + 1) = d1;
+            *buffer.index_unchecked_mut(id) = data;
         }
     }
 
-    pub fn copy(input: &[Vec4], output: &mut [Vec4], id: usize) {
+    pub fn copy(input: &[DiReservoirData], output: &mut [DiReservoirData], id: usize) {
         // TODO optimize
         Self::read(input, id).write(output, id);
     }
@@ -119,7 +122,7 @@ impl DiSample {
     pub fn ray(self, hit_point: Vec3) -> Ray {
         let dir = hit_point - self.light_point;
 
-        Ray::new(self.light_point, dir.normalize()).with_len(dir.length())
+        Ray::new(self.light_point, crate::safe_normalize(dir)).with_len(dir.length())
     }
 }
 
@@ -147,7 +150,7 @@ mod tests {
             }
         }
 
-        let mut buffer = [Vec4::ZERO; 2 * 10];
+        let mut buffer = [DiReservoirData::default(), DiReservoirData::default()];
 
         for idx in 0..10 {
             target(idx).write(&mut buffer, idx);

--- a/strolle-gpu/src/surface.rs
+++ b/strolle-gpu/src/surface.rs
@@ -1,4 +1,4 @@
-use glam::{UVec2, Vec3, Vec4Swizzles};
+use glam::{UVec2, Vec2, Vec3, Vec4Swizzles};
 #[cfg(target_arch = "spirv")]
 use spirv_std::num_traits::Float;
 
@@ -60,10 +60,19 @@ impl<'a> SurfaceMap<'a> {
     pub fn get(self, screen_pos: UVec2) -> Surface {
         let d0 = self.tex.read(screen_pos);
 
+        let depth = d0.x;
+        let normal = Normal::decode(Vec2::new(d0.y, d0.z));
+
+        let packed = d0.w.to_bits();
+        let roughness_u = (packed >> 16) & 0xFF;
+        let roughness = roughness_u as f32 / 255.0;
+
         Surface {
-            normal: Normal::decode(d0.xy()),
-            depth: d0.z,
-            roughness: d0.w,
+            normal: normal,
+            depth: depth,
+            roughness: roughness,
         }
     }
 }
+
+

--- a/strolle-gpu/src/triangle.rs
+++ b/strolle-gpu/src/triangle.rs
@@ -70,7 +70,7 @@ impl Triangle {
         let pvec = ray.dir().cross(v0v2);
         let det = v0v1.dot(pvec);
 
-        if det.abs() < f32::EPSILON {
+        if det.abs() < crate::STROLLE_EPSILON {
             return false;
         }
 

--- a/strolle-gpu/src/utils.rs
+++ b/strolle-gpu/src/utils.rs
@@ -6,7 +6,7 @@ mod vec3_ext;
 
 use core::ops;
 
-use glam::{uvec2, UVec2};
+use glam::{uvec2, UVec2, Vec3};
 use spirv_std::Image;
 
 pub use self::bilinear_filter::*;
@@ -41,3 +41,26 @@ pub fn resolve_checkerboard_alt(global_id: UVec2, frame: u32) -> UVec2 {
 pub fn got_checkerboard_at(screen_pos: UVec2, frame: u32) -> bool {
     screen_pos == resolve_checkerboard(screen_pos / uvec2(2, 1), frame)
 }
+
+pub fn safe_normalize(v: Vec3) -> Vec3 {
+    let len = v.length();
+    if len > 0.0 && len < 1_000_000.0 {
+        v / len
+    } else {
+        Vec3::ZERO
+    }
+}
+
+pub fn safe_any_orthonormal_pair(normal: Vec3) -> (Vec3, Vec3) {
+    // Choose a helper vector that is not parallel to the normal
+    let helper = if normal.x * normal.x > normal.z * normal.z {
+        Vec3::new(normal.y, -normal.x, 0.0)
+    } else {
+        Vec3::new(0.0, -normal.z, normal.y)
+    };
+    let tangent = safe_normalize(normal.cross(helper));
+    let bitangent = normal.cross(tangent);
+    (tangent, bitangent)
+}
+
+pub const STROLLE_EPSILON: f32 = 0.000_0001;

--- a/strolle-gpu/src/utils/f32_ext.rs
+++ b/strolle-gpu/src/utils/f32_ext.rs
@@ -21,7 +21,7 @@ impl F32Ext for f32 {
     }
 
     fn inverse_sqrt(self) -> Self {
-        1.0 / self.sqrt()
+        1.0 / self.max(crate::STROLLE_EPSILON).sqrt()
     }
 
     fn acos_approx(self) -> Self {

--- a/strolle-shader-builder/Cargo.toml
+++ b/strolle-shader-builder/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-spirv-builder = { git = "https://github.com/EmbarkStudios/rust-gpu" }
+spirv-builder = { git = "https://github.com/glasspangolin/rust-gpu.git" }

--- a/strolle-shaders/Cargo.toml
+++ b/strolle-shaders/Cargo.toml
@@ -11,4 +11,4 @@ crate-type = ["dylib"]
 strolle-gpu = { path = "../strolle-gpu" }
 
 # Crates.io
-spirv-std = { git = "https://github.com/EmbarkStudios/rust-gpu" }
+spirv-std = { git = "https://github.com/glasspangolin/rust-gpu.git" }

--- a/strolle-shaders/src/di_sampling.rs
+++ b/strolle-shaders/src/di_sampling.rs
@@ -19,9 +19,9 @@ pub fn main(
     #[spirv(descriptor_set = 0, binding = 7, uniform)] world: &World,
     #[spirv(descriptor_set = 1, binding = 0, uniform)] camera: &Camera,
     #[spirv(descriptor_set = 1, binding = 1)] prim_gbuffer_d0: TexRgba32,
-    #[spirv(descriptor_set = 1, binding = 2)] prim_gbuffer_d1: TexRgba32,
+    #[spirv(descriptor_set = 1, binding = 2)] prim_gbuffer_d1: TexRgba16,
     #[spirv(descriptor_set = 1, binding = 3, storage_buffer)]
-    out_reservoirs: &mut [Vec4],
+    out_reservoirs: &mut [DiReservoirData],
 ) {
     let screen_pos = global_id.xy();
     let screen_idx = camera.screen_to_idx(screen_pos);

--- a/strolle-shaders/src/di_spatial_resampling.rs
+++ b/strolle-shaders/src/di_spatial_resampling.rs
@@ -8,9 +8,9 @@ pub fn pick(
     lights: &[Light],
     #[spirv(descriptor_set = 1, binding = 0, uniform)] camera: &Camera,
     #[spirv(descriptor_set = 1, binding = 1)] prim_gbuffer_d0: TexRgba32,
-    #[spirv(descriptor_set = 1, binding = 2)] prim_gbuffer_d1: TexRgba32,
+    #[spirv(descriptor_set = 1, binding = 2)] prim_gbuffer_d1: TexRgba16,
     #[spirv(descriptor_set = 1, binding = 3, storage_buffer)]
-    reservoirs: &[Vec4],
+    reservoirs: &[DiReservoirData],
     #[spirv(descriptor_set = 1, binding = 4)] buf_d0: TexRgba32,
     #[spirv(descriptor_set = 1, binding = 5)] buf_d1: TexRgba32,
 ) {
@@ -214,9 +214,9 @@ pub fn sample(
     #[spirv(push_constant)] params: &PassParams,
     #[spirv(descriptor_set = 0, binding = 0, uniform)] camera: &Camera,
     #[spirv(descriptor_set = 0, binding = 1, storage_buffer)]
-    in_reservoirs: &[Vec4],
+    in_reservoirs: &[DiReservoirData],
     #[spirv(descriptor_set = 0, binding = 2, storage_buffer)]
-    out_reservoirs: &mut [Vec4],
+    out_reservoirs: &mut [DiReservoirData],
     #[spirv(descriptor_set = 0, binding = 3)] buf_d2: TexRgba32,
 ) {
     let global_id = global_id.xy();

--- a/strolle-shaders/src/di_temporal_resampling.rs
+++ b/strolle-shaders/src/di_temporal_resampling.rs
@@ -10,13 +10,13 @@ pub fn main(
     #[spirv(descriptor_set = 1, binding = 1, uniform)] prev_camera: &Camera,
     #[spirv(descriptor_set = 1, binding = 2)] reprojection_map: TexRgba32,
     #[spirv(descriptor_set = 1, binding = 3)] curr_prim_gbuffer_d0: TexRgba32,
-    #[spirv(descriptor_set = 1, binding = 4)] curr_prim_gbuffer_d1: TexRgba32,
+    #[spirv(descriptor_set = 1, binding = 4)] curr_prim_gbuffer_d1: TexRgba16,
     #[spirv(descriptor_set = 1, binding = 5)] prev_prim_gbuffer_d0: TexRgba32,
-    #[spirv(descriptor_set = 1, binding = 6)] prev_prim_gbuffer_d1: TexRgba32,
+    #[spirv(descriptor_set = 1, binding = 6)] prev_prim_gbuffer_d1: TexRgba16,
     #[spirv(descriptor_set = 1, binding = 7, storage_buffer)]
-    prev_reservoirs: &[Vec4],
+    prev_reservoirs: &[DiReservoirData],
     #[spirv(descriptor_set = 1, binding = 8, storage_buffer)]
-    curr_reservoirs: &mut [Vec4],
+    curr_reservoirs: &mut [DiReservoirData],
 ) {
     let lhs_pos = global_id.xy();
     let lhs_idx = curr_camera.screen_to_idx(lhs_pos);

--- a/strolle-shaders/src/frame_composition.rs
+++ b/strolle-shaders/src/frame_composition.rs
@@ -20,7 +20,7 @@ pub fn fs(
     #[spirv(frag_coord)] pos: Vec4,
     #[spirv(push_constant)] params: &FrameCompositionPassParams,
     #[spirv(descriptor_set = 0, binding = 0)] prim_gbuffer_d0: TexRgba32,
-    #[spirv(descriptor_set = 0, binding = 1)] prim_gbuffer_d1: TexRgba32,
+    #[spirv(descriptor_set = 0, binding = 1)] prim_gbuffer_d1: TexRgba16,
     #[spirv(descriptor_set = 0, binding = 2)] di_diff_colors: TexRgba32,
     #[spirv(descriptor_set = 0, binding = 3)] di_spec_colors: TexRgba32,
     #[spirv(descriptor_set = 0, binding = 4)] gi_diff_colors: TexRgba32,

--- a/strolle-shaders/src/frame_denoising.rs
+++ b/strolle-shaders/src/frame_denoising.rs
@@ -4,7 +4,7 @@ use strolle_gpu::prelude::*;
 pub fn reproject(
     #[spirv(global_invocation_id)] global_id: UVec3,
     #[spirv(descriptor_set = 0, binding = 0, uniform)] camera: &Camera,
-    #[spirv(descriptor_set = 0, binding = 1)] prim_surface_map: TexRgba32,
+    #[spirv(descriptor_set = 0, binding = 1)] prim_gbuffer_d0: TexRgba32,
     #[spirv(descriptor_set = 0, binding = 2)] reprojection_map: TexRgba32,
     #[spirv(descriptor_set = 1, binding = 0)] prev_colors: TexRgba32,
     #[spirv(descriptor_set = 1, binding = 1)] prev_moments: TexRgba32,
@@ -13,7 +13,7 @@ pub fn reproject(
     #[spirv(descriptor_set = 1, binding = 4)] moments: TexRgba32,
 ) {
     let screen_pos = global_id.xy();
-    let prim_surface_map = SurfaceMap::new(prim_surface_map);
+    let prim_surface_map = SurfaceMap::new(prim_gbuffer_d0);
     let reprojection_map = ReprojectionMap::new(reprojection_map);
 
     if !camera.contains(screen_pos) {
@@ -81,7 +81,7 @@ pub fn reproject(
 pub fn estimate_variance(
     #[spirv(global_invocation_id)] global_id: UVec3,
     #[spirv(descriptor_set = 0, binding = 0, uniform)] camera: &Camera,
-    #[spirv(descriptor_set = 0, binding = 1)] prim_surface_map: TexRgba32,
+    #[spirv(descriptor_set = 0, binding = 1)] prim_gbuffer_d0: TexRgba32,
     #[spirv(descriptor_set = 1, binding = 0)] di_colors: TexRgba32,
     #[spirv(descriptor_set = 1, binding = 1)] di_moments: TexRgba32,
     #[spirv(descriptor_set = 1, binding = 2)] di_output: TexRgba32,
@@ -90,7 +90,7 @@ pub fn estimate_variance(
     #[spirv(descriptor_set = 2, binding = 2)] gi_output: TexRgba32,
 ) {
     let screen_pos = global_id.xy();
-    let prim_surface_map = SurfaceMap::new(prim_surface_map);
+    let prim_surface_map = SurfaceMap::new(prim_gbuffer_d0);
 
     if !camera.contains(screen_pos) {
         return;
@@ -222,7 +222,7 @@ pub fn wavelet(
     #[spirv(push_constant)] params: &FrameDenoisingWaveletPassParams,
     #[spirv(descriptor_set = 0, binding = 0)] blue_noise_tex: TexRgba8,
     #[spirv(descriptor_set = 0, binding = 1, uniform)] camera: &Camera,
-    #[spirv(descriptor_set = 0, binding = 2)] prim_surface_map: TexRgba32,
+    #[spirv(descriptor_set = 0, binding = 2)] prim_gbuffer_d0: TexRgba32,
     #[spirv(descriptor_set = 1, binding = 0)] di_input: TexRgba32,
     #[spirv(descriptor_set = 1, binding = 1)] di_output: TexRgba32,
     #[spirv(descriptor_set = 2, binding = 0)] gi_input: TexRgba32,
@@ -230,7 +230,7 @@ pub fn wavelet(
 ) {
     let screen_pos = global_id.xy();
     let bnoise = BlueNoise::new(blue_noise_tex, screen_pos, params.frame);
-    let prim_surface_map = SurfaceMap::new(prim_surface_map);
+    let prim_surface_map = SurfaceMap::new(prim_gbuffer_d0);
 
     if !camera.contains(screen_pos) {
         return;

--- a/strolle-shaders/src/frame_reprojection.rs
+++ b/strolle-shaders/src/frame_reprojection.rs
@@ -8,14 +8,14 @@ pub fn main(
     #[spirv(global_invocation_id)] global_id: UVec3,
     #[spirv(descriptor_set = 0, binding = 0, uniform)] camera: &Camera,
     #[spirv(descriptor_set = 0, binding = 1, uniform)] prev_camera: &Camera,
-    #[spirv(descriptor_set = 0, binding = 2)] prim_surface_map: TexRgba32,
-    #[spirv(descriptor_set = 0, binding = 3)] prev_prim_surface_map: TexRgba32,
-    #[spirv(descriptor_set = 0, binding = 4)] velocity_map: TexRgba32,
+    #[spirv(descriptor_set = 0, binding = 2)] prim_gbuffer_d0: TexRgba32,
+    #[spirv(descriptor_set = 0, binding = 3)] prev_prim_gbuffer_d0: TexRgba32,
+    #[spirv(descriptor_set = 0, binding = 4)] velocity_map: TexRgba16,
     #[spirv(descriptor_set = 0, binding = 5)] reprojection_map: TexRgba32,
 ) {
     let screen_pos = global_id.xy();
-    let prim_surface_map = SurfaceMap::new(prim_surface_map);
-    let prev_prim_surface_map = SurfaceMap::new(prev_prim_surface_map);
+    let prim_surface_map = SurfaceMap::new(prim_gbuffer_d0);
+    let prev_prim_surface_map = SurfaceMap::new(prev_prim_gbuffer_d0);
     let reprojection_map = ReprojectionMap::new(reprojection_map);
 
     if !camera.contains(screen_pos) {

--- a/strolle-shaders/src/gi_preview_resampling.rs
+++ b/strolle-shaders/src/gi_preview_resampling.rs
@@ -6,19 +6,18 @@ pub fn main(
     #[spirv(push_constant)] params: &GiPreviewResamplingPass,
     #[spirv(descriptor_set = 0, binding = 0, uniform)] camera: &Camera,
     #[spirv(descriptor_set = 0, binding = 1)] prim_gbuffer_d0: TexRgba32,
-    #[spirv(descriptor_set = 0, binding = 2)] prim_gbuffer_d1: TexRgba32,
-    #[spirv(descriptor_set = 0, binding = 3)] prim_surface_map: TexRgba32,
-    #[spirv(descriptor_set = 0, binding = 4, storage_buffer)]
+    #[spirv(descriptor_set = 0, binding = 2)] prim_gbuffer_d1: TexRgba16,
+    #[spirv(descriptor_set = 0, binding = 3, storage_buffer)]
     in_reservoirs_a: &[Vec4],
-    #[spirv(descriptor_set = 0, binding = 5, storage_buffer)]
+    #[spirv(descriptor_set = 0, binding = 4, storage_buffer)]
     in_reservoirs_b: &[Vec4],
-    #[spirv(descriptor_set = 0, binding = 6, storage_buffer)]
+    #[spirv(descriptor_set = 0, binding = 5, storage_buffer)]
     out_reservoirs: &mut [Vec4],
 ) {
     let center_pos = global_id.xy();
     let center_idx = camera.screen_to_idx(center_pos);
     let mut wnoise = WhiteNoise::new(params.seed, center_pos);
-    let prim_surface_map = SurfaceMap::new(prim_surface_map);
+    let prim_surface_map = SurfaceMap::new(prim_gbuffer_d0);
 
     if !camera.contains(center_pos) {
         return;

--- a/strolle-shaders/src/gi_reprojection.rs
+++ b/strolle-shaders/src/gi_reprojection.rs
@@ -5,7 +5,7 @@ pub fn main(
     #[spirv(global_invocation_id)] global_id: UVec3,
     #[spirv(descriptor_set = 0, binding = 0, uniform)] camera: &Camera,
     #[spirv(descriptor_set = 0, binding = 1)] prim_gbuffer_d0: TexRgba32,
-    #[spirv(descriptor_set = 0, binding = 2)] prim_gbuffer_d1: TexRgba32,
+    #[spirv(descriptor_set = 0, binding = 2)] prim_gbuffer_d1: TexRgba16,
     #[spirv(descriptor_set = 0, binding = 3)] reprojection_map: TexRgba32,
     #[spirv(descriptor_set = 0, binding = 4, storage_buffer)]
     in_reservoirs: &[Vec4],

--- a/strolle-shaders/src/gi_resolving.rs
+++ b/strolle-shaders/src/gi_resolving.rs
@@ -6,7 +6,7 @@ pub fn main(
     #[spirv(push_constant)] params: &GiResolvingPassParams,
     #[spirv(descriptor_set = 0, binding = 0, uniform)] camera: &Camera,
     #[spirv(descriptor_set = 0, binding = 1)] prim_gbuffer_d0: TexRgba32,
-    #[spirv(descriptor_set = 0, binding = 2)] prim_gbuffer_d1: TexRgba32,
+    #[spirv(descriptor_set = 0, binding = 2)] prim_gbuffer_d1: TexRgba16,
     #[spirv(descriptor_set = 0, binding = 3, storage_buffer)]
     in_reservoirs_a: &[Vec4],
     #[spirv(descriptor_set = 0, binding = 4, storage_buffer)]

--- a/strolle-shaders/src/gi_sampling_a.rs
+++ b/strolle-shaders/src/gi_sampling_a.rs
@@ -15,7 +15,7 @@ pub fn main(
     #[spirv(descriptor_set = 0, binding = 4)] atlas_sampler: &Sampler,
     #[spirv(descriptor_set = 1, binding = 0, uniform)] camera: &Camera,
     #[spirv(descriptor_set = 1, binding = 1)] prim_gbuffer_d0: TexRgba32,
-    #[spirv(descriptor_set = 1, binding = 2)] prim_gbuffer_d1: TexRgba32,
+    #[spirv(descriptor_set = 1, binding = 2)] prim_gbuffer_d1: TexRgba16,
     #[spirv(descriptor_set = 1, binding = 3)] gi_d0: TexRgba32,
     #[spirv(descriptor_set = 1, binding = 4)] gi_d1: TexRgba32,
     #[spirv(descriptor_set = 1, binding = 5)] gi_d2: TexRgba32,

--- a/strolle-shaders/src/gi_sampling_b.rs
+++ b/strolle-shaders/src/gi_sampling_b.rs
@@ -25,7 +25,7 @@ pub fn main(
     #[spirv(descriptor_set = 1, binding = 4)]
     atmosphere_sky_lut_sampler: &Sampler,
     #[spirv(descriptor_set = 1, binding = 5)] prim_gbuffer_d0: TexRgba32,
-    #[spirv(descriptor_set = 1, binding = 6)] prim_gbuffer_d1: TexRgba32,
+    #[spirv(descriptor_set = 1, binding = 6)] prim_gbuffer_d1: TexRgba16,
     #[spirv(descriptor_set = 1, binding = 7)] gi_d0: TexRgba32,
     #[spirv(descriptor_set = 1, binding = 8)] gi_d1: TexRgba32,
     #[spirv(descriptor_set = 1, binding = 9)] gi_d2: TexRgba32,
@@ -197,7 +197,7 @@ pub fn main(
 
     if gi_hit.is_some() {
         radiance *= gi_hit.gbuffer.base_color.xyz() / PI;
-        radiance += gi_hit.gbuffer.emissive;
+        radiance += gi_hit.gbuffer.emissive * 60.0;//Emissive strength should be parameterised somehow.
     }
 
     // -------------------------------------------------------------------------

--- a/strolle-shaders/src/gi_spatial_resampling.rs
+++ b/strolle-shaders/src/gi_spatial_resampling.rs
@@ -6,7 +6,7 @@ pub fn pick(
     #[spirv(push_constant)] params: &PassParams,
     #[spirv(descriptor_set = 0, binding = 0, uniform)] camera: &Camera,
     #[spirv(descriptor_set = 0, binding = 1)] prim_gbuffer_d0: TexRgba32,
-    #[spirv(descriptor_set = 0, binding = 2)] prim_gbuffer_d1: TexRgba32,
+    #[spirv(descriptor_set = 0, binding = 2)] prim_gbuffer_d1: TexRgba16,
     #[spirv(descriptor_set = 0, binding = 3, storage_buffer)]
     reservoirs: &[Vec4],
     #[spirv(descriptor_set = 0, binding = 4)] buf_d0: TexRgba32,

--- a/strolle-shaders/src/gi_temporal_resampling.rs
+++ b/strolle-shaders/src/gi_temporal_resampling.rs
@@ -7,9 +7,9 @@ pub fn main(
     #[spirv(descriptor_set = 0, binding = 0, uniform)] curr_camera: &Camera,
     #[spirv(descriptor_set = 0, binding = 1, uniform)] prev_camera: &Camera,
     #[spirv(descriptor_set = 0, binding = 2)] curr_prim_gbuffer_d0: TexRgba32,
-    #[spirv(descriptor_set = 0, binding = 3)] curr_prim_gbuffer_d1: TexRgba32,
+    #[spirv(descriptor_set = 0, binding = 3)] curr_prim_gbuffer_d1: TexRgba16,
     #[spirv(descriptor_set = 0, binding = 4)] prev_prim_gbuffer_d0: TexRgba32,
-    #[spirv(descriptor_set = 0, binding = 5)] prev_prim_gbuffer_d1: TexRgba32,
+    #[spirv(descriptor_set = 0, binding = 5)] prev_prim_gbuffer_d1: TexRgba16,
     #[spirv(descriptor_set = 0, binding = 6)] reprojection_map: TexRgba32,
     #[spirv(descriptor_set = 0, binding = 7, storage_buffer)]
     prev_reservoirs: &[Vec4],

--- a/strolle-shaders/src/prim_raster.rs
+++ b/strolle-shaders/src/prim_raster.rs
@@ -59,7 +59,6 @@ pub fn fs(
     // Outputs
     out_prim_gbuffer_d0: &mut Vec4,
     out_prim_gbuffer_d1: &mut Vec4,
-    out_surface: &mut Vec4,
     out_velocity: &mut Vec4,
 ) {
     let material = MaterialsView::new(materials)
@@ -102,12 +101,6 @@ pub fn fs(
 
     *out_prim_gbuffer_d0 = gbuffer_d0;
     *out_prim_gbuffer_d1 = gbuffer_d1;
-
-    // -------------------------------------------------------------------------
-
-    *out_surface = Normal::encode(normal)
-        .extend(depth)
-        .extend(material.roughness);
 
     // -------------------------------------------------------------------------
 

--- a/strolle-shaders/src/ref_shading.rs
+++ b/strolle-shaders/src/ref_shading.rs
@@ -50,7 +50,7 @@ pub fn main(
 
     // -------------------------------------------------------------------------
 
-    if params.depth == u8::MAX as u32 {
+    if params.depth == 255u32 {
         let prev_color = if camera.is_eq(*prev_camera) {
             colors.read(screen_pos)
         } else {

--- a/strolle/Cargo.toml
+++ b/strolle/Cargo.toml
@@ -12,14 +12,14 @@ strolle-shaders = { path = "../strolle-shaders" }
 bytemuck = "1.13.1"
 derivative = "2.2.0"
 fxhash = "0.2.1"
-glam = "0.24"
+glam = "0.27.0"
 guillotiere = "0.6.2"
 humantime = { version = "2.1.0", optional = true }
 image = { version = "0.24.6", default-features = false, features = ["png"] }
 log = "0.4.18"
 rand = "0.8.5"
-spirv-std = { git = "https://github.com/EmbarkStudios/rust-gpu" }
-wgpu = { version = "0.17.2", features = ["spirv"] }
+spirv-std = { git = "https://github.com/glasspangolin/rust-gpu.git" }
+wgpu = { version = "0.20.1", features = ["spirv"] }
 
 [features]
 metrics = ["humantime"]

--- a/strolle/src/bvh/builder.rs
+++ b/strolle/src/bvh/builder.rs
@@ -4,7 +4,6 @@ use std::hash::{Hash, Hasher};
 use std::thread;
 
 use fxhash::FxHasher;
-use glam::UVec3;
 
 use super::{
     BvhNode, BvhNodeHash, BvhNodeId, BvhNodes, BvhPrimitiveId, BvhPrimitives,
@@ -86,7 +85,7 @@ fn find_splitting_plane(
 
     let centroid_bb: BoundingBox = primitives
         .iter()
-        .map(|primitive| primitive.center)
+        .map(|primitive| -> glam::Vec3 {primitive.center})
         .collect();
 
     let mut bins = [[Bin::default(); BINS]; 3];
@@ -94,7 +93,7 @@ fn find_splitting_plane(
 
     for primitive in primitives {
         let bin_id = scale * (primitive.center - centroid_bb.min());
-        let bin_id = bin_id.as_uvec3().min(UVec3::splat((BINS as u32) - 1));
+        let bin_id = bin_id.as_uvec3().min(glam::UVec3::splat((BINS as u32) - 1));
         let bin_idx = bin_id.x as usize;
         let bin_idy = bin_id.y as usize;
         let bin_idz = bin_id.z as usize;
@@ -165,8 +164,8 @@ fn find_splitting_plane(
             if is_current_bin_better {
                 let split_by = Axis::from(axis);
 
-                let split_at = centroid_bb.min()[split_by]
-                    + scale[split_by] * ((i + 1) as f32);
+                let split_at = centroid_bb.min()[split_by as usize]
+                    + scale[split_by as usize] * ((i + 1) as f32);
 
                 best = Some(SplittingPlane {
                     split_by,
@@ -211,7 +210,7 @@ fn split(
     while left_prim_idx <= right_prim_idx {
         let primitive = primitives_data[left_prim_idx as usize];
 
-        if primitive.center[plane.split_by] < plane.split_at {
+        if primitive.center[plane.split_by as usize] < plane.split_at {
             left_prim_idx += 1;
             left_bounds += primitive.bounds;
 

--- a/strolle/src/bvh/serializer.rs
+++ b/strolle/src/bvh/serializer.rs
@@ -8,7 +8,7 @@ pub fn run<P>(
     materials: &Materials<P>,
     nodes: &BvhNodes,
     primitives: &BvhPrimitives,
-    buffer: &mut Vec<Vec4>,
+    buffer: &mut Vec<spirv_std::glam::Vec4>,
 ) where
     P: Params,
 {
@@ -21,7 +21,7 @@ fn serialize<P>(
     materials: &Materials<P>,
     nodes: &BvhNodes,
     primitives: &BvhPrimitives,
-    buffer: &mut Vec<Vec4>,
+    buffer: &mut Vec<spirv_std::glam::Vec4>,
     id: BvhNodeId,
 ) -> u32
 where

--- a/strolle/src/camera.rs
+++ b/strolle/src/camera.rs
@@ -1,9 +1,10 @@
 use std::fmt;
 
 use log::info;
-use spirv_std::glam::{uvec2, Mat4, UVec2, Vec3};
+use glam::{uvec2, Mat4, UVec2, Vec3};
 
 use crate::gpu;
+use crate::utils::ToGpu;
 
 #[derive(Clone, Debug, Default)]
 pub struct Camera {
@@ -49,19 +50,19 @@ impl Camera {
 
     pub(crate) fn serialize(&self) -> gpu::Camera {
         gpu::Camera {
-            projection_view: self.projection * self.transform.inverse(),
-            ndc_to_world: self.transform * self.projection.inverse(),
-            origin: self
+            projection_view: (self.projection * self.transform.inverse()).to_gpu(),
+            ndc_to_world: (self.transform * self.projection.inverse()).to_gpu(),
+            origin: (self
                 .transform
                 .to_scale_rotation_translation()
                 .2
-                .extend(Default::default()),
-            screen: self
+                .extend(Default::default())).to_gpu(),
+            screen: (self
                 .viewport
                 .size
                 .as_vec2()
                 .extend(Default::default())
-                .extend(Default::default()),
+                .extend(Default::default())).to_gpu(),
         }
     }
 }

--- a/strolle/src/camera_controller/buffers.rs
+++ b/strolle/src/camera_controller/buffers.rs
@@ -1,8 +1,9 @@
 use log::debug;
-
+use strolle_gpu::DiReservoirData;
 use crate::{
     gpu, Camera, DoubleBuffered, MappedUniformBuffer, StorageBuffer, Texture,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct CameraBuffers {
@@ -16,7 +17,6 @@ pub struct CameraBuffers {
     pub prim_depth: Texture,
     pub prim_gbuffer_d0: DoubleBuffered<Texture>,
     pub prim_gbuffer_d1: DoubleBuffered<Texture>,
-    pub prim_surface_map: DoubleBuffered<Texture>,
 
     pub reprojection_map: Texture,
     pub velocity_map: Texture,
@@ -99,7 +99,7 @@ impl CameraBuffers {
         // ---------------------------------------------------------------------
 
         let prim_depth = Texture::builder("prim_depth")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Depth32Float)
             .with_usage(wgpu::TextureUsages::RENDER_ATTACHMENT)
             .build(device);
@@ -107,7 +107,7 @@ impl CameraBuffers {
         let prim_gbuffer_d0 = DoubleBuffered::<Texture>::new(
             device,
             Texture::builder("prim_gbuffer_d0")
-                .with_size(camera.viewport.size)
+                .with_size(camera.viewport.size.to_gpu())
                 .with_format(wgpu::TextureFormat::Rgba32Float)
                 .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
                 .with_usage(wgpu::TextureUsages::RENDER_ATTACHMENT),
@@ -116,17 +116,8 @@ impl CameraBuffers {
         let prim_gbuffer_d1 = DoubleBuffered::<Texture>::new(
             device,
             Texture::builder("prim_gbuffer_d1")
-                .with_size(camera.viewport.size)
-                .with_format(wgpu::TextureFormat::Rgba32Float)
-                .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
-                .with_usage(wgpu::TextureUsages::RENDER_ATTACHMENT),
-        );
-
-        let prim_surface_map = DoubleBuffered::<Texture>::new(
-            device,
-            Texture::builder("prim_surface_map")
-                .with_size(camera.viewport.size)
-                .with_format(wgpu::TextureFormat::Rgba32Float)
+                .with_size(camera.viewport.size.to_gpu())
+                .with_format(wgpu::TextureFormat::Rgba16Float)
                 .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
                 .with_usage(wgpu::TextureUsages::RENDER_ATTACHMENT),
         );
@@ -134,44 +125,46 @@ impl CameraBuffers {
         // ---------------------------------------------------------------------
 
         let reprojection_map = Texture::builder("reprojection_map")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
 
         let velocity_map = Texture::builder("velocity_map")
-            .with_size(camera.viewport.size)
-            .with_format(wgpu::TextureFormat::Rgba32Float)
+            .with_size(camera.viewport.size.to_gpu())
+            .with_format(wgpu::TextureFormat::Rgba16Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .with_usage(wgpu::TextureUsages::RENDER_ATTACHMENT)
             .build(device);
 
         // ---------------------------------------------------------------------
 
+        let element_size = std::mem::size_of::<DiReservoirData>();
+        let element_size_round = (element_size as f32 / 32.0).ceil() as usize * 32;
         let di_reservoirs = [0, 1, 2].map(|idx| {
             StorageBuffer::new(
                 device,
                 format!("di_reservoir_{}", idx),
-                viewport_buffer_size(2 * 4 * 4),
+                viewport_buffer_size(element_size_round),
             )
         });
 
         // ---
 
         let di_diff_samples = Texture::builder("di_diff_samples")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
 
         let di_diff_prev_colors = Texture::builder("di_diff_prev_colors")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
 
         let di_diff_curr_colors = Texture::builder("di_diff_curr_colors")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
@@ -179,13 +172,13 @@ impl CameraBuffers {
         let di_diff_moments = DoubleBuffered::<Texture>::new(
             device,
             Texture::builder("di_diff_moments")
-                .with_size(camera.viewport.size)
+                .with_size(camera.viewport.size.to_gpu())
                 .with_format(wgpu::TextureFormat::Rgba32Float)
                 .with_usage(wgpu::TextureUsages::STORAGE_BINDING),
         );
 
         let di_diff_stash = Texture::builder("di_diff_stash")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
@@ -193,7 +186,7 @@ impl CameraBuffers {
         // ---
 
         let di_spec_samples = Texture::builder("di_spec_samples")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
@@ -201,19 +194,19 @@ impl CameraBuffers {
         // ---------------------------------------------------------------------
 
         let gi_d0 = Texture::builder("gi_d0")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
 
         let gi_d1 = Texture::builder("gi_d1")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
 
         let gi_d2 = Texture::builder("gi_d2")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
@@ -229,19 +222,19 @@ impl CameraBuffers {
         // ---
 
         let gi_diff_samples = Texture::builder("gi_diff_samples")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
 
         let gi_diff_prev_colors = Texture::builder("gi_diff_prev_colors")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
 
         let gi_diff_curr_colors = Texture::builder("gi_diff_curr_colors")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
@@ -249,13 +242,13 @@ impl CameraBuffers {
         let gi_diff_moments = DoubleBuffered::<Texture>::new(
             device,
             Texture::builder("gi_diff_moments")
-                .with_size(camera.viewport.size)
+                .with_size(camera.viewport.size.to_gpu())
                 .with_format(wgpu::TextureFormat::Rgba32Float)
                 .with_usage(wgpu::TextureUsages::STORAGE_BINDING),
         );
 
         let gi_diff_stash = Texture::builder("gi_diff_stash")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
@@ -263,7 +256,7 @@ impl CameraBuffers {
         // ---
 
         let gi_spec_samples = Texture::builder("gi_spec_samples")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
@@ -286,7 +279,7 @@ impl CameraBuffers {
 
         // TODO initialize lazily
         let ref_colors = Texture::builder("ref_colors")
-            .with_size(camera.viewport.size)
+            .with_size(camera.viewport.size.to_gpu())
             .with_format(wgpu::TextureFormat::Rgba32Float)
             .with_usage(wgpu::TextureUsages::STORAGE_BINDING)
             .build(device);
@@ -304,7 +297,6 @@ impl CameraBuffers {
             prim_depth,
             prim_gbuffer_d0,
             prim_gbuffer_d1,
-            prim_surface_map,
 
             reprojection_map,
             velocity_map,

--- a/strolle/src/camera_controller/pass.rs
+++ b/strolle/src/camera_controller/pass.rs
@@ -42,6 +42,7 @@ where
         let mut pass =
             encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
                 label: Some(&label),
+                timestamp_writes: None,
             });
 
         pass.set_pipeline(&self.pipeline);
@@ -136,7 +137,8 @@ where
                 label: Some(&pipeline_label),
                 layout: Some(&pipeline_layout),
                 module,
-                entry_point,
+                entry_point: entry_point,
+                compilation_options: Default::default(),
             });
 
         CameraComputePass {

--- a/strolle/src/camera_controller/passes/bvh_heatmap.rs
+++ b/strolle/src/camera_controller/passes/bvh_heatmap.rs
@@ -1,6 +1,7 @@
 use crate::{
     Camera, CameraBuffers, CameraComputePass, CameraController, Engine, Params,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct BvhHeatmapPass {
@@ -41,6 +42,6 @@ impl BvhHeatmapPass {
         // This pass uses 8x8 warps:
         let size = (camera.camera.viewport.size + 7) / 8;
 
-        self.pass.run(camera, encoder, size, ());
+        self.pass.run(camera, encoder, size.to_gpu(), ());
     }
 }

--- a/strolle/src/camera_controller/passes/di_resolving.rs
+++ b/strolle/src/camera_controller/passes/di_resolving.rs
@@ -1,6 +1,7 @@
 use crate::{
     Camera, CameraBuffers, CameraComputePass, CameraController, Engine, Params,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct DiResolvingPass {
@@ -50,6 +51,6 @@ impl DiResolvingPass {
         // This pass uses 8x8 warps:
         let size = (camera.camera.viewport.size + 7) / 8;
 
-        self.pass.run(camera, encoder, size, camera.pass_params());
+        self.pass.run(camera, encoder, size.to_gpu(), camera.pass_params());
     }
 }

--- a/strolle/src/camera_controller/passes/di_sampling.rs
+++ b/strolle/src/camera_controller/passes/di_sampling.rs
@@ -1,6 +1,7 @@
 use crate::{
     Camera, CameraBuffers, CameraComputePass, CameraController, Engine, Params,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct DiSamplingPass {
@@ -46,6 +47,6 @@ impl DiSamplingPass {
         // This pass uses 8x8 warps:
         let size = (camera.camera.viewport.size + 7) / 8;
 
-        self.pass.run(camera, encoder, size, camera.pass_params());
+        self.pass.run(camera, encoder, size.to_gpu(), camera.pass_params());
     }
 }

--- a/strolle/src/camera_controller/passes/di_spatial_resampling.rs
+++ b/strolle/src/camera_controller/passes/di_spatial_resampling.rs
@@ -3,6 +3,7 @@ use glam::uvec2;
 use crate::{
     Camera, CameraBuffers, CameraComputePass, CameraController, Engine, Params,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct DiSpatialResamplingPass {
@@ -81,21 +82,21 @@ impl DiSpatialResamplingPass {
         self.pick_pass.run(
             camera,
             encoder,
-            (camera.camera.viewport.size + 7) / 8 / uvec2(2, 1),
+            ((camera.camera.viewport.size + 7) / 8 / uvec2(2, 1)).to_gpu(),
             camera.pass_params(),
         );
 
         self.trace_pass.run(
             camera,
             encoder,
-            (camera.camera.viewport.size + 7) / 8,
+            ((camera.camera.viewport.size + 7) / 8).to_gpu(),
             camera.pass_params(),
         );
 
         self.sample_pass.run(
             camera,
             encoder,
-            (camera.camera.viewport.size + 7) / 8 / uvec2(2, 1),
+            ((camera.camera.viewport.size + 7) / 8 / uvec2(2, 1)).to_gpu(),
             camera.pass_params(),
         );
     }

--- a/strolle/src/camera_controller/passes/di_temporal_resampling.rs
+++ b/strolle/src/camera_controller/passes/di_temporal_resampling.rs
@@ -1,6 +1,7 @@
 use crate::{
     Camera, CameraBuffers, CameraComputePass, CameraController, Engine, Params,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct DiTemporalResamplingPass {
@@ -43,6 +44,6 @@ impl DiTemporalResamplingPass {
         // This pass uses 8x8 warps:
         let size = (camera.camera.viewport.size + 7) / 8;
 
-        self.pass.run(camera, encoder, size, camera.pass_params());
+        self.pass.run(camera, encoder, size.to_gpu(), camera.pass_params());
     }
 }

--- a/strolle/src/camera_controller/passes/frame_composition.rs
+++ b/strolle/src/camera_controller/passes/frame_composition.rs
@@ -77,6 +77,7 @@ impl FrameCompositionPass {
                 vertex: wgpu::VertexState {
                     module: &engine.shaders.frame_composition_vs.0,
                     entry_point: engine.shaders.frame_composition_vs.1,
+                    compilation_options: Default::default(),
                     buffers: &[],
                 },
                 primitive: wgpu::PrimitiveState::default(),
@@ -85,6 +86,7 @@ impl FrameCompositionPass {
                 fragment: Some(wgpu::FragmentState {
                     module: &engine.shaders.frame_composition_fs.0,
                     entry_point: engine.shaders.frame_composition_fs.1,
+                    compilation_options: Default::default(),
                     targets: &[Some(wgpu::ColorTargetState {
                         format: camera.viewport.format,
                         blend: Some(wgpu::BlendState::REPLACE),
@@ -112,10 +114,12 @@ impl FrameCompositionPass {
                 resolve_target: None,
                 ops: wgpu::Operations {
                     load: wgpu::LoadOp::Load,
-                    store: true,
+                    store: wgpu::StoreOp::Store,
                 },
             })],
             depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
         });
 
         let params = gpu::FrameCompositionPassParams {

--- a/strolle/src/camera_controller/passes/frame_reprojection.rs
+++ b/strolle/src/camera_controller/passes/frame_reprojection.rs
@@ -1,6 +1,7 @@
 use crate::{
     Camera, CameraBuffers, CameraComputePass, CameraController, Engine, Params,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct FrameReprojectionPass {
@@ -21,8 +22,8 @@ impl FrameReprojectionPass {
             .bind([
                 &buffers.curr_camera.bind_readable(),
                 &buffers.prev_camera.bind_readable(),
-                &buffers.prim_surface_map.curr().bind_readable(),
-                &buffers.prim_surface_map.prev().bind_readable(),
+                &buffers.prim_gbuffer_d0.curr().bind_readable(),
+                &buffers.prim_gbuffer_d0.prev().bind_readable(),
                 &buffers.velocity_map.bind_readable(),
                 &buffers.reprojection_map.bind_writable(),
             ])
@@ -39,6 +40,6 @@ impl FrameReprojectionPass {
         // This pass uses 8x8 warps:
         let size = (camera.camera.viewport.size + 7) / 8;
 
-        self.pass.run(camera, encoder, size, ());
+        self.pass.run(camera, encoder, size.to_gpu(), ());
     }
 }

--- a/strolle/src/camera_controller/passes/gi_preview_resampling.rs
+++ b/strolle/src/camera_controller/passes/gi_preview_resampling.rs
@@ -2,6 +2,7 @@ use crate::{
     gpu, Camera, CameraBuffers, CameraComputePass, CameraController, Engine,
     Params,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct GiPreviewResamplingPass {
@@ -23,7 +24,6 @@ impl GiPreviewResamplingPass {
                 &buffers.curr_camera.bind_readable(),
                 &buffers.prim_gbuffer_d0.curr().bind_readable(),
                 &buffers.prim_gbuffer_d1.curr().bind_readable(),
-                &buffers.prim_surface_map.curr().bind_readable(),
                 &buffers.gi_reservoirs[1].bind_readable(),
                 &buffers.gi_reservoirs[2].bind_readable(),
                 &buffers.gi_reservoirs[3].bind_writable(),
@@ -35,7 +35,6 @@ impl GiPreviewResamplingPass {
                 &buffers.curr_camera.bind_readable(),
                 &buffers.prim_gbuffer_d0.curr().bind_readable(),
                 &buffers.prim_gbuffer_d1.curr().bind_readable(),
-                &buffers.prim_surface_map.curr().bind_readable(),
                 &buffers.gi_reservoirs[1].bind_readable(),
                 &buffers.gi_reservoirs[3].bind_readable(),
                 &buffers.gi_reservoirs[0].bind_writable(),
@@ -63,7 +62,7 @@ impl GiPreviewResamplingPass {
             pass.run(
                 camera,
                 encoder,
-                size,
+                size.to_gpu(),
                 gpu::GiPreviewResamplingPass {
                     seed: params.seed,
                     frame: params.frame,

--- a/strolle/src/camera_controller/passes/gi_reprojection.rs
+++ b/strolle/src/camera_controller/passes/gi_reprojection.rs
@@ -1,6 +1,7 @@
 use crate::{
     Camera, CameraBuffers, CameraComputePass, CameraController, Engine, Params,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct GiReprojectionPass {
@@ -39,6 +40,6 @@ impl GiReprojectionPass {
         // This pass uses 8x8 warps:
         let size = (camera.camera.viewport.size + 7) / 8;
 
-        self.pass.run(camera, encoder, size, camera.pass_params());
+        self.pass.run(camera, encoder, size.to_gpu(), camera.pass_params());
     }
 }

--- a/strolle/src/camera_controller/passes/gi_resolving.rs
+++ b/strolle/src/camera_controller/passes/gi_resolving.rs
@@ -2,6 +2,7 @@ use crate::{
     gpu, Camera, CameraBuffers, CameraComputePass, CameraController, Engine,
     Params,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct GiResolvingPass {
@@ -46,7 +47,7 @@ impl GiResolvingPass {
         self.pass.run(
             camera,
             encoder,
-            size,
+            size.to_gpu(),
             gpu::GiResolvingPassParams {
                 frame: camera.frame,
                 source,

--- a/strolle/src/camera_controller/passes/gi_sampling.rs
+++ b/strolle/src/camera_controller/passes/gi_sampling.rs
@@ -3,6 +3,7 @@ use glam::uvec2;
 use crate::{
     Camera, CameraBuffers, CameraComputePass, CameraController, Engine, Params,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct GiSamplingPass {
@@ -72,7 +73,7 @@ impl GiSamplingPass {
         // These passes use 8x8 warps and 2x1 checkerboard:
         let size = (camera.camera.viewport.size + 7) / 8 / uvec2(2, 1);
 
-        self.pass_a.run(camera, encoder, size, camera.pass_params());
-        self.pass_b.run(camera, encoder, size, camera.pass_params());
+        self.pass_a.run(camera, encoder, size.to_gpu(), camera.pass_params());
+        self.pass_b.run(camera, encoder, size.to_gpu(), camera.pass_params());
     }
 }

--- a/strolle/src/camera_controller/passes/gi_spatial_resampling.rs
+++ b/strolle/src/camera_controller/passes/gi_spatial_resampling.rs
@@ -3,6 +3,7 @@ use glam::uvec2;
 use crate::{
     Camera, CameraBuffers, CameraComputePass, CameraController, Engine, Params,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct GiSpatialResamplingPass {
@@ -74,21 +75,21 @@ impl GiSpatialResamplingPass {
         self.pick_pass.run(
             camera,
             encoder,
-            (camera.camera.viewport.size + 7) / 8 / uvec2(2, 1),
+            ((camera.camera.viewport.size + 7) / 8 / uvec2(2, 1)).to_gpu(),
             camera.pass_params(),
         );
 
         self.trace_pass.run(
             camera,
             encoder,
-            (camera.camera.viewport.size + 7) / 8,
+            ((camera.camera.viewport.size + 7) / 8).to_gpu(),
             camera.pass_params(),
         );
 
         self.sample_pass.run(
             camera,
             encoder,
-            (camera.camera.viewport.size + 7) / 8 / uvec2(2, 1),
+            ((camera.camera.viewport.size + 7) / 8 / uvec2(2, 1)).to_gpu(),
             camera.pass_params(),
         );
     }

--- a/strolle/src/camera_controller/passes/gi_temporal_resampling.rs
+++ b/strolle/src/camera_controller/passes/gi_temporal_resampling.rs
@@ -1,6 +1,7 @@
 use crate::{
     Camera, CameraBuffers, CameraComputePass, CameraController, Engine, Params,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct GiTemporalResamplingPass {
@@ -42,6 +43,6 @@ impl GiTemporalResamplingPass {
         // This pass uses 8x8 warps:
         let size = (camera.camera.viewport.size + 7) / 8;
 
-        self.pass.run(camera, encoder, size, camera.pass_params());
+        self.pass.run(camera, encoder, size.to_gpu(), camera.pass_params());
     }
 }

--- a/strolle/src/camera_controller/passes/ref_shading.rs
+++ b/strolle/src/camera_controller/passes/ref_shading.rs
@@ -4,6 +4,7 @@ use crate::{
     gpu, Camera, CameraBuffers, CameraComputePass, CameraController, Engine,
     Params,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct RefShadingPass {
@@ -58,6 +59,6 @@ impl RefShadingPass {
             depth: depth as u32,
         };
 
-        self.pass.run(camera, encoder, size, params);
+        self.pass.run(camera, encoder, size.to_gpu(), params);
     }
 }

--- a/strolle/src/camera_controller/passes/ref_tracing.rs
+++ b/strolle/src/camera_controller/passes/ref_tracing.rs
@@ -4,6 +4,7 @@ use crate::{
     gpu, Camera, CameraBuffers, CameraComputePass, CameraController, Engine,
     Params,
 };
+use crate::utils::ToGpu;
 
 #[derive(Debug)]
 pub struct RefTracingPass {
@@ -52,6 +53,6 @@ impl RefTracingPass {
             depth: depth as u32,
         };
 
-        self.pass.run(camera, encoder, size, params);
+        self.pass.run(camera, encoder, size.to_gpu(), params);
     }
 }

--- a/strolle/src/images.rs
+++ b/strolle/src/images.rs
@@ -5,8 +5,9 @@ use derivative::Derivative;
 use glam::{uvec2, vec4, Vec4};
 use guillotiere::{size2, Allocation, AtlasAllocator};
 use log::warn;
-
+use wgpu::TextureFormat;
 use crate::{Bindable, Image, ImageData, Params, Texture};
+use crate::utils::ToGpu;
 
 #[derive(Derivative)]
 #[derivative(Debug)]
@@ -22,6 +23,40 @@ where
     dynamic_textures: Vec<(P::ImageTexture, Allocation)>,
 }
 
+fn convert_to_rgba8unorm_srgb(
+    data: &[u8],
+    src_format: wgpu::TextureFormat,
+    width: u32,
+    height: u32,
+) -> Vec<u8> {
+    let pixel_count = (width * height) as usize;
+    let mut converted_data = Vec::with_capacity(pixel_count * 4);
+
+    match src_format {
+        wgpu::TextureFormat::R8Unorm => {
+            for &r in data {
+                converted_data.extend_from_slice(&[r, 0, 0, 255]);
+            }
+        }
+        wgpu::TextureFormat::Rg8Unorm => {
+            for chunk in data.chunks_exact(2) {
+                let r = chunk[0];
+                let g = chunk[1];
+                converted_data.extend_from_slice(&[r, g, 0, 255]);
+            }
+        }
+        wgpu::TextureFormat::Rgba8UnormSrgb => {
+            converted_data.extend_from_slice(data);
+        }
+        _ => {
+            println!("Unhandled texture format: {:?}", src_format);
+        }
+    }
+
+    converted_data
+}
+
+
 impl<P> Images<P>
 where
     P: Params,
@@ -36,7 +71,7 @@ where
         ));
 
         let atlas_texture = Texture::builder("atlas")
-            .with_size(uvec2(Self::ATLAS_WIDTH, Self::ATLAS_HEIGHT))
+            .with_size(uvec2(Self::ATLAS_WIDTH, Self::ATLAS_HEIGHT).to_gpu())
             .with_format(wgpu::TextureFormat::Rgba8UnormSrgb)
             .with_usage(wgpu::TextureUsages::TEXTURE_BINDING)
             .with_usage(wgpu::TextureUsages::COPY_DST)
@@ -85,13 +120,55 @@ where
             | ImageData::Texture {
                 is_dynamic: false, ..
             }) => {
-                self.atlas_changes.push(AtlasChange::Set {
-                    x: alloc.rectangle.min.x as u32,
-                    y: alloc.rectangle.min.y as u32,
-                    w: alloc.rectangle.width() as u32,
-                    h: alloc.rectangle.height() as u32,
-                    data,
-                });
+                match &data {
+                    ImageData::Raw { data } => {
+                        // Convert data to atlas format (Rgba8UnormSrgb)
+                        let converted_data = convert_to_rgba8unorm_srgb(
+                            data,
+                            item.texture_descriptor.format,
+                            item.texture_descriptor.size.width,
+                            item.texture_descriptor.size.height,
+                        );
+
+                        // Use atlas texture's format for calculations
+                        let block_size = 4; // Rgba8UnormSrgb has 4 bytes per pixel
+                        let unpadded_bytes_per_row =
+                            item.texture_descriptor.size.width * block_size;
+                        let padding = (256 - (unpadded_bytes_per_row % 256)) % 256;
+                        let padded_bytes_per_row = unpadded_bytes_per_row + padding;
+
+                        // Pad the converted data if necessary
+                        let mut padded_data = Vec::with_capacity(
+                            (padded_bytes_per_row * item.texture_descriptor.size.height) as usize,
+                        );
+                        if padding == 0 {
+                            padded_data = converted_data;
+                        } else {
+                            let row_length = (unpadded_bytes_per_row) as usize;
+                            for row in converted_data.chunks_exact(row_length) {
+                                padded_data.extend_from_slice(row);
+                                padded_data.extend(std::iter::repeat(0).take(padding as usize));
+                            }
+                        }
+
+                        self.atlas_changes.push(AtlasChange::Set {
+                            x: alloc.rectangle.min.x as u32,
+                            y: alloc.rectangle.min.y as u32,
+                            w: alloc.rectangle.width() as u32,
+                            h: alloc.rectangle.height() as u32,
+                            data: ImageData::Raw { data: padded_data },
+                        });
+                    }
+                    ImageData::Texture { texture, .. } => {
+                        self.atlas_changes.push(AtlasChange::Set {
+                            x: alloc.rectangle.min.x as u32,
+                            y: alloc.rectangle.min.y as u32,
+                            w: alloc.rectangle.width() as u32,
+                            h: alloc.rectangle.height() as u32,
+                            data: data,
+                        });
+                    }
+                };
             }
 
             ImageData::Texture {
@@ -140,6 +217,23 @@ where
 
                     match data {
                         ImageData::Raw { data } => {
+                            // Use atlas texture's format for calculations
+                            let block_size = 4; // Rgba8UnormSrgb has 4 bytes per pixel
+                            let unpadded_bytes_per_row = w * block_size;
+                            let padding = (256 - (unpadded_bytes_per_row % 256)) % 256;
+                            let padded_bytes_per_row = unpadded_bytes_per_row + padding;
+
+                            println!(
+                                "Writing texture: pos={}x{}, size={}x{}, data_len={}, bytes_per_row={}, padded_bytes_per_row={}",
+                                x,
+                                y,
+                                w,
+                                h,
+                                data.len(),
+                                unpadded_bytes_per_row,
+                                padded_bytes_per_row
+                            );
+
                             queue.write_texture(
                                 wgpu::ImageCopyTexture {
                                     texture: self.atlas_texture.tex(),
@@ -150,14 +244,10 @@ where
                                 &data,
                                 wgpu::ImageDataLayout {
                                     offset: 0,
-                                    bytes_per_row: Some(w * 4),
+                                    bytes_per_row: Some(padded_bytes_per_row),
                                     rows_per_image: None,
                                 },
-                                wgpu::Extent3d {
-                                    width: w,
-                                    height: h,
-                                    depth_or_array_layers: 1,
-                                },
+                                size,
                             );
                         }
 

--- a/strolle/src/lib.rs
+++ b/strolle/src/lib.rs
@@ -75,9 +75,11 @@ use std::ops::Deref;
 use std::time::Instant;
 use std::{env, mem};
 
-pub use glam;
+use glam;
 use log::{info, trace};
 use strolle_gpu as gpu;
+
+pub use crate::utils::interface::ToGpu;
 
 pub(crate) use self::buffers::*;
 pub(crate) use self::bvh::*;

--- a/strolle/src/light.rs
+++ b/strolle/src/light.rs
@@ -1,6 +1,7 @@
 use glam::{vec4, Vec3};
 
 use crate::gpu;
+use crate::utils::ToGpu;
 
 #[derive(Clone, Debug)]
 pub enum Light {
@@ -53,7 +54,7 @@ impl Light {
                 direction,
                 angle,
             } => {
-                let direction = gpu::Normal::encode(*direction);
+                let direction = gpu::Normal::encode((*direction).to_gpu());
 
                 d0 = position.extend(*radius);
                 d1 = color.extend(*range);
@@ -68,9 +69,9 @@ impl Light {
         }
 
         gpu::Light {
-            d0,
-            d1,
-            d2,
+            d0: d0.to_gpu(),
+            d1: d1.to_gpu(),
+            d2: d2.to_gpu(),
             d3: Default::default(),
             prev_d0: Default::default(),
             prev_d1: Default::default(),

--- a/strolle/src/material.rs
+++ b/strolle/src/material.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use spirv_std::glam::{vec4, Vec4};
 
 use crate::{gpu, Images, Params};
+use crate::utils::ToGpu;
 
 #[derive(Clone, Debug)]
 pub struct Material<P>
@@ -31,21 +32,21 @@ where
             base_color: self.base_color,
             base_color_texture: images
                 .lookup_opt(self.base_color_texture)
-                .unwrap_or_default(),
+                .unwrap_or_default().to_gpu(),
             emissive: self.emissive,
             emissive_texture: images
                 .lookup_opt(self.emissive_texture)
-                .unwrap_or_default(),
+                .unwrap_or_default().to_gpu(),
             roughness: self.perceptual_roughness.powf(2.0),
             metallic: self.metallic,
             metallic_roughness_texture: images
                 .lookup_opt(self.metallic_roughness_texture)
-                .unwrap_or_default(),
+                .unwrap_or_default().to_gpu(),
             reflectance: self.reflectance,
             ior: self.ior,
             normal_map_texture: images
                 .lookup_opt(self.normal_map_texture)
-                .unwrap_or_default(),
+                .unwrap_or_default().to_gpu(),
         }
     }
 }

--- a/strolle/src/mesh_triangle.rs
+++ b/strolle/src/mesh_triangle.rs
@@ -1,6 +1,5 @@
-use glam::Affine3A;
-use spirv_std::glam::{Mat4, Vec2, Vec3, Vec4, Vec4Swizzles};
 
+use glam::{Vec2, Vec3, Vec4, Mat4, Affine3A, Vec4Swizzles};
 use crate::Triangle;
 
 #[derive(Clone, Debug, Default)]
@@ -17,17 +16,17 @@ impl MeshTriangle {
         self
     }
 
-    pub fn with_normals(mut self, normals: [impl Into<Vec3>; 3]) -> Self {
-        self.normals = normals.map(Into::into);
+    pub fn with_normals(mut self, normals: [Vec3; 3]) -> Self {
+        self.normals = normals;
         self
     }
 
-    pub fn with_uvs(mut self, uvs: [impl Into<Vec2>; 3]) -> Self {
-        self.uvs = uvs.map(Into::into);
+    pub fn with_uvs(mut self, uvs: [Vec2; 3]) -> Self {
+        self.uvs = uvs;
         self
     }
 
-    pub fn with_tangents(mut self, tangents: [impl Into<Vec4>; 3]) -> Self {
+    pub fn with_tangents(mut self, tangents: [Vec4; 3]) -> Self {
         self.tangents = tangents.map(Into::into);
         self
     }
@@ -49,8 +48,8 @@ impl MeshTriangle {
         xform: Affine3A,
         xform_inv: Affine3A,
     ) -> Triangle {
-        let positions =
-            self.positions.map(|vertex| xform.transform_point3(vertex));
+        let positions: [Vec3; 3] =
+            self.positions.map(|vertex: Vec3| -> Vec3 {xform.transform_point3(vertex)});
 
         let normals = {
             // Transforming normals requires inversing and transposing the
@@ -77,10 +76,12 @@ impl MeshTriangle {
             })
         };
 
+        let uvs = self.uvs.map(|uv| {uv});
+
         Triangle {
             positions,
             normals,
-            uvs: self.uvs,
+            uvs,
             tangents,
         }
     }

--- a/strolle/src/triangle.rs
+++ b/strolle/src/triangle.rs
@@ -1,8 +1,8 @@
 use glam::Vec3Swizzles;
-use spirv_std::glam::{Vec2, Vec3, Vec4};
+use glam::{Vec2, Vec3, Vec4};
 
 use crate::gpu;
-use crate::utils::BoundingBox;
+use crate::utils::{BoundingBox, ToGpu};
 
 #[derive(Clone, Debug)]
 pub struct Triangle {
@@ -23,17 +23,17 @@ impl Triangle {
 
     pub fn serialize(&self) -> gpu::Triangle {
         gpu::Triangle {
-            d0: self.positions[0].xyz().extend(self.uvs[0].x),
-            d1: self.normals[0].xyz().extend(self.uvs[0].y),
-            d2: self.tangents[0],
+            d0: self.positions[0].xyz().extend(self.uvs[0].x).to_gpu(),
+            d1: self.normals[0].xyz().extend(self.uvs[0].y).to_gpu(),
+            d2: self.tangents[0].to_gpu(),
 
-            d3: self.positions[1].xyz().extend(self.uvs[1].x),
-            d4: self.normals[1].xyz().extend(self.uvs[1].y),
-            d5: self.tangents[1],
+            d3: self.positions[1].xyz().extend(self.uvs[1].x).to_gpu(),
+            d4: self.normals[1].xyz().extend(self.uvs[1].y).to_gpu(),
+            d5: self.tangents[1].to_gpu(),
 
-            d6: self.positions[2].xyz().extend(self.uvs[2].x),
-            d7: self.normals[2].xyz().extend(self.uvs[2].y),
-            d8: self.tangents[2],
+            d6: self.positions[2].xyz().extend(self.uvs[2].x).to_gpu(),
+            d7: self.normals[2].xyz().extend(self.uvs[2].y).to_gpu(),
+            d8: self.tangents[2].to_gpu(),
         }
     }
 }

--- a/strolle/src/utils.rs
+++ b/strolle/src/utils.rs
@@ -2,8 +2,12 @@ mod allocator;
 mod axis;
 mod bounding_box;
 mod metrics;
+pub mod interface;
 
 pub use self::allocator::*;
 pub use self::axis::*;
 pub use self::bounding_box::*;
 pub use self::metrics::*;
+pub use self::interface::*;
+
+

--- a/strolle/src/utils/bounding_box.rs
+++ b/strolle/src/utils/bounding_box.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, AddAssign};
 
-use spirv_std::glam::Vec3;
+use glam::Vec3;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BoundingBox {

--- a/strolle/src/utils/interface.rs
+++ b/strolle/src/utils/interface.rs
@@ -1,0 +1,58 @@
+// First, let's define helper traits for converting between CPU and GPU types
+use glam as cpu;
+use spirv_std::glam as gpu;
+
+// Helper trait for converting CPU types to GPU types
+pub trait ToGpu<T> {
+    fn to_gpu(&self) -> T;
+}
+
+
+impl ToGpu<gpu::Affine3A> for cpu::Affine3A {
+    fn to_gpu(&self) -> gpu::Affine3A {
+        gpu::Affine3A::from_cols_array(&self.to_cols_array())
+    }
+}
+
+impl ToGpu<gpu::Mat4> for cpu::Mat4 {
+    fn to_gpu(&self) -> gpu::Mat4 {
+        gpu::Mat4::from_cols_array(&self.to_cols_array())
+    }
+}
+
+impl ToGpu<gpu::Vec4> for cpu::Vec4 {
+    fn to_gpu(&self) -> gpu::Vec4 {
+        gpu::Vec4::new(self.x, self.y, self.z, self.w)
+    }
+}
+
+impl ToGpu<gpu::Vec3> for cpu::Vec3 {
+    fn to_gpu(&self) -> gpu::Vec3 {
+        gpu::Vec3::new(self.x, self.y, self.z)
+    }
+}
+
+impl ToGpu<gpu::Vec2> for cpu::Vec2 {
+    fn to_gpu(&self) -> gpu::Vec2 {
+        gpu::Vec2::new(self.x, self.y)
+    }
+}
+
+
+impl ToGpu<gpu::UVec2> for cpu::UVec2 {
+    fn to_gpu(&self) -> gpu::UVec2 {
+        gpu::UVec2::new(self.x, self.y)
+    }
+}
+
+impl ToGpu<gpu::UVec3> for cpu::UVec3 {
+    fn to_gpu(&self) -> gpu::UVec3 {
+        gpu::UVec3::new(self.x, self.y, self.z)
+    }
+}
+
+impl ToGpu<gpu::UVec4> for cpu::UVec4 {
+    fn to_gpu(&self) -> gpu::UVec4 {
+        gpu::UVec4::new(self.x, self.y, self.z, self.w)
+    }
+}


### PR DESCRIPTION
Key observations of the commit are:
- more careful memory management to comply with newer stricter WGPU. 
   - The prim_raster move from 64 bytes to 32 bytes to satisfy a compile time WGPU limit.
   - the DiReservoirData struct. I recognise it's probably a downgrade since I've gone from 16->64 bytes per entry, but it was more readable for me and I think it solved a WGPU compile issue. Feel free to revert.
   - Figuring out padding and alignment was difficult, and I fear it might be platform dependent validation by WGPU. I found at least on my laptop the limit in size for the prim_raster buffers was 32 (2xRgba32Float). The byte alignment for texture buffers was 256, and the alignment for buffers within the shader ecosystem was 32. You may find yours is different at which point we may have to find a dynamic solution.
   - safe_any_orthonormal_pair as the glam any_orthonormal_pair was flagged by WGPU as a potential source of NaN.
- upgraded rust-gpu depending on a more recent nightly rust.
   - I think I have to patch in the entire bevy engine from my github just to add the inline_const feature flag.
   - I have also hosted rust-gpu as I feel the slightest change there would break everything, feel free to revert to the official repo or your own hosted version. 
- A lot of subtle changes to bevy, I did what I could to keep the functionality as similar as possible.

I hope this is ok! Feel free to tear this apart as it's my first contribution to a repo. I want to learn and I'm happy to go back to the drawing board!
